### PR TITLE
Optimise NDVI notebook for distributed dask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 
 # Environments
 .env
+
+# Dask
+dask-worker-space/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 
 # Dask
 dask-worker-space/
+
+# Tiff
+dask_conversions/**/*.tiff

--- a/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
+++ b/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
@@ -229,8 +229,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 12.4 ms, sys: 67 µs, total: 12.5 ms\n",
-      "Wall time: 12 ms\n"
+      "CPU times: user 13.4 ms, sys: 246 µs, total: 13.6 ms\n",
+      "Wall time: 13.1 ms\n"
      ]
     }
    ],
@@ -250,8 +250,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4 µs, sys: 0 ns, total: 4 µs\n",
-      "Wall time: 10.5 µs\n"
+      "CPU times: user 4 µs, sys: 1 µs, total: 5 µs\n",
+      "Wall time: 11.4 µs\n"
      ]
     }
    ],
@@ -291,8 +291,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 141 ms, sys: 175 µs, total: 141 ms\n",
-      "Wall time: 140 ms\n"
+      "CPU times: user 150 ms, sys: 16.3 ms, total: 166 ms\n",
+      "Wall time: 165 ms\n"
      ]
     }
    ],
@@ -364,8 +364,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8 µs, sys: 1 µs, total: 9 µs\n",
-      "Wall time: 14.8 µs\n"
+      "CPU times: user 8 µs, sys: 1e+03 ns, total: 9 µs\n",
+      "Wall time: 14.1 µs\n"
      ]
     }
    ],
@@ -392,9 +392,9 @@
    "outputs": [],
    "source": [
     "dask_chunks=dict(\n",
-    "    time = 100,\n",
-    "    x = 400,\n",
-    "    y = 400\n",
+    "    time = 40,\n",
+    "    x = 2000,\n",
+    "    y = 2000\n",
     ")"
    ]
   },
@@ -408,8 +408,8 @@
      "output_type": "stream",
      "text": [
       "(datetime.date(2015, 3, 1), datetime.date(2015, 9, 1))\n",
-      "CPU times: user 1.7 ms, sys: 0 ns, total: 1.7 ms\n",
-      "Wall time: 1.62 ms\n"
+      "CPU times: user 1.85 ms, sys: 0 ns, total: 1.85 ms\n",
+      "Wall time: 1.82 ms\n"
      ]
     }
    ],
@@ -592,8 +592,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 744 ms, sys: 35.8 ms, total: 780 ms\n",
-      "Wall time: 835 ms\n"
+      "CPU times: user 875 ms, sys: 40.5 ms, total: 915 ms\n",
+      "Wall time: 970 ms\n"
      ]
     }
    ],
@@ -617,8 +617,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 628 ms, sys: 17.1 ms, total: 645 ms\n",
-      "Wall time: 695 ms\n"
+      "CPU times: user 584 ms, sys: 31.3 ms, total: 615 ms\n",
+      "Wall time: 664 ms\n"
      ]
     }
    ],
@@ -735,8 +735,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 126 ms, sys: 0 ns, total: 126 ms\n",
-      "Wall time: 130 ms\n"
+      "CPU times: user 67.2 ms, sys: 0 ns, total: 67.2 ms\n",
+      "Wall time: 66.6 ms\n"
      ]
     }
    ],
@@ -900,8 +900,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 9.49 ms, sys: 277 µs, total: 9.77 ms\n",
-      "Wall time: 9.69 ms\n"
+      "CPU times: user 10.2 ms, sys: 0 ns, total: 10.2 ms\n",
+      "Wall time: 10.1 ms\n"
      ]
     }
    ],
@@ -920,8 +920,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 11.3 ms, sys: 0 ns, total: 11.3 ms\n",
-      "Wall time: 10.9 ms\n"
+      "CPU times: user 10.9 ms, sys: 505 µs, total: 11.4 ms\n",
+      "Wall time: 11 ms\n"
      ]
     }
    ],
@@ -940,8 +940,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 62 ms, sys: 0 ns, total: 62 ms\n",
-      "Wall time: 61.4 ms\n"
+      "CPU times: user 65.5 ms, sys: 0 ns, total: 65.5 ms\n",
+      "Wall time: 64.8 ms\n"
      ]
     }
    ],
@@ -999,8 +999,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 12.9 ms, sys: 164 µs, total: 13.1 ms\n",
-      "Wall time: 12.9 ms\n"
+      "CPU times: user 13.5 ms, sys: 0 ns, total: 13.5 ms\n",
+      "Wall time: 13.4 ms\n"
      ]
     }
    ],
@@ -1022,8 +1022,8 @@
      "text": [
       "0.15.0\n",
       "2.12.0\n",
-      "CPU times: user 2.33 ms, sys: 0 ns, total: 2.33 ms\n",
-      "Wall time: 2.27 ms\n"
+      "CPU times: user 1.79 ms, sys: 324 µs, total: 2.11 ms\n",
+      "Wall time: 2.18 ms\n"
      ]
     }
    ],
@@ -1038,15 +1038,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 733 ms, sys: 34.4 ms, total: 768 ms\n",
-      "Wall time: 1min\n"
+      "CPU times: user 700 ms, sys: 11.9 ms, total: 712 ms\n",
+      "Wall time: 1min 1s\n"
      ]
     }
    ],
@@ -1075,7 +1075,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7efd44ca0160>"
+       "<matplotlib.collections.QuadMesh at 0x7fb71fc0c0f0>"
       ]
      },
      "execution_count": 40,

--- a/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
+++ b/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
@@ -209,7 +209,7 @@
     "analysis_end_date = '2016-9-1'\n",
     "\n",
     "# Select the cloud-free mosaic type\n",
-    "# Options are: max_ndvi, median, most_recent_pixel\n",
+    "# Options are: max_ndvi, median\n",
     "mosaic_type = \"median\""
    ]
   },
@@ -229,8 +229,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 13.4 ms, sys: 246 µs, total: 13.6 ms\n",
-      "Wall time: 13.1 ms\n"
+      "CPU times: user 7.53 ms, sys: 3.92 ms, total: 11.5 ms\n",
+      "Wall time: 11.1 ms\n"
      ]
     }
    ],
@@ -250,8 +250,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4 µs, sys: 1 µs, total: 5 µs\n",
-      "Wall time: 11.4 µs\n"
+      "CPU times: user 3 µs, sys: 1 µs, total: 4 µs\n",
+      "Wall time: 8.11 µs\n"
      ]
     }
    ],
@@ -291,8 +291,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 150 ms, sys: 16.3 ms, total: 166 ms\n",
-      "Wall time: 165 ms\n"
+      "CPU times: user 145 ms, sys: 4.15 ms, total: 149 ms\n",
+      "Wall time: 148 ms\n"
      ]
     }
    ],
@@ -364,8 +364,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8 µs, sys: 1e+03 ns, total: 9 µs\n",
-      "Wall time: 14.1 µs\n"
+      "CPU times: user 7 µs, sys: 1 µs, total: 8 µs\n",
+      "Wall time: 12.6 µs\n"
      ]
     }
    ],
@@ -408,8 +408,8 @@
      "output_type": "stream",
      "text": [
       "(datetime.date(2015, 3, 1), datetime.date(2015, 9, 1))\n",
-      "CPU times: user 1.85 ms, sys: 0 ns, total: 1.85 ms\n",
-      "Wall time: 1.82 ms\n"
+      "CPU times: user 1.2 ms, sys: 227 µs, total: 1.42 ms\n",
+      "Wall time: 1.43 ms\n"
      ]
     }
    ],
@@ -592,8 +592,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 875 ms, sys: 40.5 ms, total: 915 ms\n",
-      "Wall time: 970 ms\n"
+      "CPU times: user 673 ms, sys: 28.8 ms, total: 701 ms\n",
+      "Wall time: 753 ms\n"
      ]
     }
    ],
@@ -617,8 +617,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 584 ms, sys: 31.3 ms, total: 615 ms\n",
-      "Wall time: 664 ms\n"
+      "CPU times: user 614 ms, sys: 4.98 ms, total: 619 ms\n",
+      "Wall time: 680 ms\n"
      ]
     }
    ],
@@ -735,8 +735,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 67.2 ms, sys: 0 ns, total: 67.2 ms\n",
-      "Wall time: 66.6 ms\n"
+      "CPU times: user 65.4 ms, sys: 0 ns, total: 65.4 ms\n",
+      "Wall time: 64.7 ms\n"
      ]
     }
    ],
@@ -796,11 +796,8 @@
     }
    ],
    "source": [
-    "\n",
     "baseline_ds = baseline_ds.where(b_good_quality)\n",
     "analysis_ds = analysis_ds.where(a_good_quality)\n",
-    "#baseline_ds = odc.algo.keep_good_only(baseline_ds, where=b_good_quality)\n",
-    "#analysis_ds = odc.algo.keep_good_only(analysis_ds, where=a_good_quality)\n",
     "\n",
     "baseline_ds"
    ]
@@ -821,17 +818,28 @@
    "source": [
     "#add in geomedian - get rid of others\n",
     "mosaic_function = {\"median\": create_median_mosaic,\n",
-    "                   \"max_ndvi\": create_max_ndvi_mosaic,\n",
-    "                   \"most_recent_pixel\": create_mosaic}"
+    "                   \"max_ndvi\": create_max_ndvi_mosaic}"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<function datacube_utilities.dc_mosaic.create_median_mosaic(dataset_in, clean_mask=None, no_data=nan, dtype=None, **kwargs)>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "new_compositor = mosaic_function[mosaic_type]\n"
+    "new_compositor = mosaic_function[mosaic_type]\n",
+    "new_compositor"
    ]
   },
   {
@@ -878,8 +886,14 @@
     }
    ],
    "source": [
-    "baseline_composite = new_compositor(baseline_ds, clean_mask = b_good_quality)\n",
-    "analysis_composite = new_compositor(analysis_ds, clean_mask = a_good_quality)\n",
+    "if mosaic_type == \"median\":\n",
+    "    # create_median_mosiac works automatically with dask without using `dask.delayed`\n",
+    "    # this gives us a ~20% time saving on small datasets\n",
+    "    baseline_composite = new_compositor(baseline_ds, clean_mask = b_good_quality)\n",
+    "    analysis_composite = new_compositor(analysis_ds, clean_mask = a_good_quality)\n",
+    "else:    \n",
+    "    baseline_composite = dask.delayed(new_compositor)(baseline_ds, clean_mask = b_good_quality)\n",
+    "    analysis_composite = dask.delayed(new_compositor)(analysis_ds, clean_mask = a_good_quality)\n",
     "\n",
     "baseline_composite"
    ]
@@ -900,8 +914,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 10.2 ms, sys: 0 ns, total: 10.2 ms\n",
-      "Wall time: 10.1 ms\n"
+      "CPU times: user 9.37 ms, sys: 230 µs, total: 9.6 ms\n",
+      "Wall time: 9.53 ms\n"
      ]
     }
    ],
@@ -920,7 +934,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 10.9 ms, sys: 505 µs, total: 11.4 ms\n",
+      "CPU times: user 10.9 ms, sys: 489 µs, total: 11.4 ms\n",
       "Wall time: 11 ms\n"
      ]
     }
@@ -940,8 +954,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 65.5 ms, sys: 0 ns, total: 65.5 ms\n",
-      "Wall time: 64.8 ms\n"
+      "CPU times: user 61.1 ms, sys: 165 µs, total: 61.3 ms\n",
+      "Wall time: 60.8 ms\n"
      ]
     }
    ],
@@ -999,8 +1013,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 13.5 ms, sys: 0 ns, total: 13.5 ms\n",
-      "Wall time: 13.4 ms\n"
+      "CPU times: user 13.3 ms, sys: 0 ns, total: 13.3 ms\n",
+      "Wall time: 13.3 ms\n"
      ]
     }
    ],
@@ -1022,8 +1036,8 @@
      "text": [
       "0.15.0\n",
       "2.12.0\n",
-      "CPU times: user 1.79 ms, sys: 324 µs, total: 2.11 ms\n",
-      "Wall time: 2.18 ms\n"
+      "CPU times: user 1.88 ms, sys: 324 µs, total: 2.21 ms\n",
+      "Wall time: 2.17 ms\n"
      ]
     }
    ],
@@ -1045,8 +1059,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 700 ms, sys: 11.9 ms, total: 712 ms\n",
-      "Wall time: 1min 1s\n"
+      "CPU times: user 786 ms, sys: 35.4 ms, total: 821 ms\n",
+      "Wall time: 1min 2s\n"
      ]
     }
    ],
@@ -1075,7 +1089,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7fb71fc0c0f0>"
+       "<matplotlib.collections.QuadMesh at 0x7fa2f951aeb8>"
       ]
      },
      "execution_count": 40,

--- a/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
+++ b/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
@@ -30,129 +30,329 @@
      "output_type": "stream",
      "text": [
       "Requirement already satisfied: datacube_utilities from git+https://github.com/SatelliteApplicationsCatapult/datacube-utilities.git#egg=datacube_utilities in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (0.0.1)\n",
-      "Requirement already satisfied: geopandas==0.5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: ruamel.yaml==0.15.96 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.15.96)\n",
-      "Requirement already satisfied: scipy==1.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.3.0)\n",
-      "Requirement already satisfied: shapely==1.6.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.6.4)\n",
-      "Requirement already satisfied: scikit-image==0.15.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.15.0)\n",
-      "Requirement already satisfied: descartes==1.1.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.1.0)\n",
-      "Requirement already satisfied: ipyleaflet==0.10.8 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.10.8)\n",
       "Requirement already satisfied: dask==2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2.0.0)\n",
-      "Requirement already satisfied: seaborn==0.9.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.9.0)\n",
-      "Requirement already satisfied: folium==0.9.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.9.1)\n",
-      "Requirement already satisfied: hdmedians==0.13 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.13)\n",
       "Requirement already satisfied: lcmap-pyccd==2017.08.18 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2017.8.18)\n",
-      "Requirement already satisfied: matplotlib==3.1.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (3.1.0)\n",
-      "Requirement already satisfied: rasterstats==0.13.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.13.1)\n",
-      "Requirement already satisfied: datacube==1.7 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.7)\n",
-      "Requirement already satisfied: boto3==1.9.179 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.9.179)\n",
-      "Requirement already satisfied: scikit-learn==0.21.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.21.2)\n",
+      "Requirement already satisfied: hdmedians==0.13 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.13)\n",
+      "Requirement already satisfied: folium==0.9.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.9.1)\n",
+      "Requirement already satisfied: scipy==1.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.3.0)\n",
+      "Requirement already satisfied: scikit-image==0.15.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.15.0)\n",
       "Requirement already satisfied: distributed==2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2.0.1)\n",
-      "Requirement already satisfied: pyproj in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.5.0->datacube_utilities) (2.2.1)\n",
-      "Requirement already satisfied: pandas in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.5.0->datacube_utilities) (0.24.2)\n",
-      "Requirement already satisfied: fiona in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.5.0->datacube_utilities) (1.8.6)\n",
+      "Requirement already satisfied: geopandas==0.5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.5.0)\n",
+      "Requirement already satisfied: datacube==1.7 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.7)\n",
+      "Requirement already satisfied: ipyleaflet==0.10.8 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.10.8)\n",
+      "Requirement already satisfied: scikit-learn==0.21.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.21.2)\n",
+      "Requirement already satisfied: ruamel.yaml==0.15.96 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.15.96)\n",
+      "Requirement already satisfied: seaborn==0.9.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.9.0)\n",
+      "Requirement already satisfied: shapely==1.6.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.6.4)\n",
+      "Requirement already satisfied: rasterstats==0.13.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.13.1)\n",
+      "Requirement already satisfied: descartes==1.1.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.1.0)\n",
+      "Requirement already satisfied: matplotlib==3.1.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (3.1.0)\n",
+      "Requirement already satisfied: xarray>=0.13.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.15.1)\n",
+      "Requirement already satisfied: boto3==1.9.179 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.9.179)\n",
+      "Requirement already satisfied: click-plugins>=1.0.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (1.1.1)\n",
+      "Requirement already satisfied: PyYAML>=3.12 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (5.1)\n",
+      "Requirement already satisfied: click>=6.6 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (7.0)\n",
+      "Requirement already satisfied: cachetools>=2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (3.1.1)\n",
+      "Requirement already satisfied: numpy>=1.10.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (1.16.4)\n",
+      "Requirement already satisfied: Cython>=0.23 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from hdmedians==0.13->datacube_utilities) (0.29.15)\n",
+      "Requirement already satisfied: requests in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.9.1->datacube_utilities) (2.22.0)\n",
+      "Requirement already satisfied: branca>=0.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.9.1->datacube_utilities) (0.3.1)\n",
+      "Requirement already satisfied: jinja2>=2.9 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.9.1->datacube_utilities) (2.10.1)\n",
       "Requirement already satisfied: networkx>=2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.15.0->datacube_utilities) (2.3)\n",
       "Requirement already satisfied: pillow>=4.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.15.0->datacube_utilities) (6.0.0)\n",
       "Requirement already satisfied: imageio>=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.15.0->datacube_utilities) (2.5.0)\n",
       "Requirement already satisfied: PyWavelets>=0.4.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.15.0->datacube_utilities) (1.0.3)\n",
-      "Requirement already satisfied: branca<0.4,>=0.3.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.10.8->datacube_utilities) (0.3.1)\n",
-      "Requirement already satisfied: ipywidgets<8,>=7.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.10.8->datacube_utilities) (7.4.2)\n",
-      "Requirement already satisfied: xarray>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.10.8->datacube_utilities) (0.12.1)\n",
-      "Requirement already satisfied: traittypes<3,>=0.2.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.10.8->datacube_utilities) (0.2.1)\n",
-      "Requirement already satisfied: numpy>=1.9.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from seaborn==0.9.0->datacube_utilities) (1.16.4)\n",
-      "Requirement already satisfied: requests in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.9.1->datacube_utilities) (2.22.0)\n",
-      "Requirement already satisfied: jinja2>=2.9 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.9.1->datacube_utilities) (2.10.1)\n",
-      "Requirement already satisfied: Cython>=0.23 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from hdmedians==0.13->datacube_utilities) (0.29.15)\n",
-      "Requirement already satisfied: cachetools>=2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (3.1.1)\n",
-      "Requirement already satisfied: click>=6.6 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (7.0)\n",
-      "Requirement already satisfied: click-plugins>=1.0.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (1.1.1)\n",
-      "Requirement already satisfied: PyYAML>=3.12 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (5.1)\n",
-      "Requirement already satisfied: cycler>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.1.0->datacube_utilities) (0.10.0)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.1.0->datacube_utilities) (1.1.0)\n",
-      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.1.0->datacube_utilities) (2.4.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.1.0->datacube_utilities) (2.8.0)\n",
-      "Requirement already satisfied: rasterio>=1.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.13.1->datacube_utilities) (1.0.22)\n",
-      "Requirement already satisfied: simplejson in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.13.1->datacube_utilities) (3.16.1)\n",
-      "Requirement already satisfied: cligj>=0.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.13.1->datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: netcdf4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.5.1.2)\n",
-      "Requirement already satisfied: gdal>=1.9 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.4.1)\n",
-      "Requirement already satisfied: cloudpickle>=0.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.2.1)\n",
-      "Requirement already satisfied: sqlalchemy in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.3.5)\n",
-      "Requirement already satisfied: psycopg2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.8.3)\n",
-      "Requirement already satisfied: pypeg2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.15.2)\n",
-      "Requirement already satisfied: singledispatch in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (3.4.0.3)\n",
-      "Requirement already satisfied: jsonschema in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (3.0.1)\n",
-      "Requirement already satisfied: toolz in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (0.9.0)\n",
-      "Requirement already satisfied: lark-parser>=0.6.7 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (0.8.2)\n",
-      "Requirement already satisfied: affine in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.2.2)\n",
-      "Requirement already satisfied: botocore<1.13.0,>=1.12.179 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.9.179->datacube_utilities) (1.12.179)\n",
-      "Requirement already satisfied: s3transfer<0.3.0,>=0.2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.9.179->datacube_utilities) (0.2.1)\n",
-      "Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.9.179->datacube_utilities) (0.9.4)\n",
-      "Requirement already satisfied: joblib>=0.11 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-learn==0.21.2->datacube_utilities) (0.13.2)\n",
-      "Requirement already satisfied: psutil>=5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (5.6.3)\n",
+      "Requirement already satisfied: toolz>=0.7.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (0.9.0)\n",
       "Requirement already satisfied: six in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (1.12.0)\n",
+      "Requirement already satisfied: cloudpickle>=0.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (1.2.1)\n",
+      "Requirement already satisfied: psutil>=5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (5.6.3)\n",
+      "Requirement already satisfied: msgpack in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (0.6.1)\n",
       "Requirement already satisfied: sortedcontainers!=2.0.0,!=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (2.1.0)\n",
       "Requirement already satisfied: tornado>=5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (6.0.3)\n",
-      "Requirement already satisfied: msgpack in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (0.6.1)\n",
       "Requirement already satisfied: zict>=0.1.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (1.0.0)\n",
       "Requirement already satisfied: tblib in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (1.4.0)\n",
-      "Requirement already satisfied: pytz>=2011k in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pandas->geopandas==0.5.0->datacube_utilities) (2019.1)\n",
+      "Requirement already satisfied: pyproj in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.5.0->datacube_utilities) (2.2.1)\n",
+      "Requirement already satisfied: pandas in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.5.0->datacube_utilities) (1.0.3)\n",
+      "Requirement already satisfied: fiona in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.5.0->datacube_utilities) (1.8.6)\n",
+      "Requirement already satisfied: affine in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.2.2)\n",
+      "Requirement already satisfied: python-dateutil in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.8.0)\n",
+      "Requirement already satisfied: jsonschema in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (3.0.1)\n",
+      "Requirement already satisfied: netcdf4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.5.1.2)\n",
+      "Requirement already satisfied: rasterio>=1.0.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.0.22)\n",
+      "Requirement already satisfied: singledispatch in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (3.4.0.3)\n",
+      "Requirement already satisfied: pypeg2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.15.2)\n",
+      "Requirement already satisfied: gdal>=1.9 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.4.1)\n",
+      "Requirement already satisfied: lark-parser>=0.6.7 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (0.8.2)\n",
+      "Requirement already satisfied: sqlalchemy in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.3.5)\n",
+      "Requirement already satisfied: psycopg2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.8.3)\n",
+      "Requirement already satisfied: traittypes<3,>=0.2.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.10.8->datacube_utilities) (0.2.1)\n",
+      "Requirement already satisfied: ipywidgets<8,>=7.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.10.8->datacube_utilities) (7.4.2)\n",
+      "Requirement already satisfied: joblib>=0.11 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-learn==0.21.2->datacube_utilities) (0.13.2)\n",
+      "Requirement already satisfied: cligj>=0.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.13.1->datacube_utilities) (0.5.0)\n",
+      "Requirement already satisfied: simplejson in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.13.1->datacube_utilities) (3.16.1)\n",
+      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.1.0->datacube_utilities) (2.4.0)\n",
+      "Requirement already satisfied: cycler>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.1.0->datacube_utilities) (0.10.0)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.1.0->datacube_utilities) (1.1.0)\n",
+      "Requirement already satisfied: setuptools>=41.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from xarray>=0.13.0->datacube_utilities) (46.1.1)\n",
+      "Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.9.179->datacube_utilities) (0.9.4)\n",
+      "Requirement already satisfied: botocore<1.13.0,>=1.12.179 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.9.179->datacube_utilities) (1.12.179)\n",
+      "Requirement already satisfied: s3transfer<0.3.0,>=0.2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.9.179->datacube_utilities) (0.2.1)\n",
+      "Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (3.0.4)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (2019.6.16)\n",
+      "Requirement already satisfied: idna<2.9,>=2.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (2.8)\n",
+      "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (1.24.3)\n",
+      "Requirement already satisfied: MarkupSafe>=0.23 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jinja2>=2.9->folium==0.9.1->datacube_utilities) (1.1.1)\n",
+      "Requirement already satisfied: decorator>=4.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from networkx>=2.0->scikit-image==0.15.0->datacube_utilities) (4.4.0)\n",
+      "Requirement already satisfied: heapdict in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from zict>=0.1.3->distributed==2.0.1->datacube_utilities) (1.0.0)\n",
+      "Requirement already satisfied: pytz>=2017.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pandas->geopandas==0.5.0->datacube_utilities) (2019.1)\n",
       "Requirement already satisfied: attrs>=17 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from fiona->geopandas==0.5.0->datacube_utilities) (19.1.0)\n",
       "Requirement already satisfied: munch in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from fiona->geopandas==0.5.0->datacube_utilities) (2.3.2)\n",
-      "Requirement already satisfied: decorator>=4.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from networkx>=2.0->scikit-image==0.15.0->datacube_utilities) (4.4.0)\n",
-      "Requirement already satisfied: nbformat>=4.2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (4.4.0)\n",
-      "Requirement already satisfied: traitlets>=4.3.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (4.3.2)\n",
-      "Requirement already satisfied: ipython>=4.0.0; python_version >= \"3.3\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (7.5.0)\n",
-      "Requirement already satisfied: ipykernel>=4.5.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (5.1.1)\n",
-      "Requirement already satisfied: widgetsnbextension~=3.4.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (3.4.2)\n",
-      "Requirement already satisfied: idna<2.9,>=2.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (2.8)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (2019.6.16)\n",
-      "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (1.24.3)\n",
-      "Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (3.0.4)\n",
-      "Requirement already satisfied: MarkupSafe>=0.23 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jinja2>=2.9->folium==0.9.1->datacube_utilities) (1.1.1)\n",
-      "Requirement already satisfied: setuptools in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from kiwisolver>=1.0.1->matplotlib==3.1.0->datacube_utilities) (41.0.1)\n",
-      "Requirement already satisfied: snuggs>=1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterio>=1.0->rasterstats==0.13.1->datacube_utilities) (1.4.6)\n",
-      "Requirement already satisfied: cftime in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from netcdf4->datacube==1.7->datacube_utilities) (1.0.3.4)\n",
       "Requirement already satisfied: pyrsistent>=0.14.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jsonschema->datacube==1.7->datacube_utilities) (0.15.2)\n",
+      "Requirement already satisfied: cftime in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from netcdf4->datacube==1.7->datacube_utilities) (1.0.3.4)\n",
+      "Requirement already satisfied: snuggs>=1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterio>=1.0.2->datacube==1.7->datacube_utilities) (1.4.6)\n",
+      "Requirement already satisfied: traitlets>=4.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from traittypes<3,>=0.2.1->ipyleaflet==0.10.8->datacube_utilities) (4.3.2)\n",
+      "Requirement already satisfied: widgetsnbextension~=3.4.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (3.4.2)\n",
+      "Requirement already satisfied: ipykernel>=4.5.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (5.1.1)\n",
+      "Requirement already satisfied: nbformat>=4.2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (4.4.0)\n",
+      "Requirement already satisfied: ipython>=4.0.0; python_version >= \"3.3\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (7.5.0)\n",
       "Requirement already satisfied: docutils>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from botocore<1.13.0,>=1.12.179->boto3==1.9.179->datacube_utilities) (0.14)\n",
-      "Requirement already satisfied: heapdict in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from zict>=0.1.3->distributed==2.0.1->datacube_utilities) (1.0.0)\n",
-      "Requirement already satisfied: ipython_genutils in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbformat>=4.2.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.2.0)\n",
-      "Requirement already satisfied: jupyter_core in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbformat>=4.2.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (4.4.0)\n",
-      "Requirement already satisfied: jedi>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.14.0)\n",
-      "Requirement already satisfied: prompt-toolkit<2.1.0,>=2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (2.0.9)\n",
-      "Requirement already satisfied: pexpect; sys_platform != \"win32\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (4.7.0)\n",
-      "Requirement already satisfied: pickleshare in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.7.5)\n",
-      "Requirement already satisfied: pygments in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (2.4.2)\n",
-      "Requirement already satisfied: backcall in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.1.0)\n",
-      "Requirement already satisfied: jupyter-client in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipykernel>=4.5.1->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (5.2.4)\n",
+      "Requirement already satisfied: ipython_genutils in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from traitlets>=4.2.2->traittypes<3,>=0.2.1->ipyleaflet==0.10.8->datacube_utilities) (0.2.0)\n",
       "Requirement already satisfied: notebook>=4.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (5.7.8)\n",
-      "Requirement already satisfied: parso>=0.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jedi>=0.10->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: wcwidth in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from prompt-toolkit<2.1.0,>=2.0.0->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.1.7)\n",
-      "Requirement already satisfied: ptyprocess>=0.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pexpect; sys_platform != \"win32\"->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.6.0)\n",
-      "Requirement already satisfied: pyzmq>=13 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jupyter-client->ipykernel>=4.5.1->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (18.0.2)\n",
-      "Requirement already satisfied: terminado>=0.8.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.8.2)\n",
-      "Requirement already satisfied: prometheus-client in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.7.1)\n",
+      "Requirement already satisfied: jupyter-client in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipykernel>=4.5.1->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (5.2.4)\n",
+      "Requirement already satisfied: jupyter_core in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbformat>=4.2.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (4.4.0)\n",
+      "Requirement already satisfied: prompt-toolkit<2.1.0,>=2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (2.0.9)\n",
+      "Requirement already satisfied: pygments in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (2.4.2)\n",
+      "Requirement already satisfied: pickleshare in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.7.5)\n",
+      "Requirement already satisfied: pexpect; sys_platform != \"win32\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (4.7.0)\n",
+      "Requirement already satisfied: jedi>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.14.0)\n",
+      "Requirement already satisfied: backcall in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.1.0)\n",
       "Requirement already satisfied: Send2Trash in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (1.5.0)\n",
       "Requirement already satisfied: nbconvert in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (5.5.0)\n",
-      "Requirement already satisfied: pandocfilters>=1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (1.4.2)\n",
-      "Requirement already satisfied: defusedxml in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: bleach in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (3.1.0)\n",
+      "Requirement already satisfied: terminado>=0.8.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.8.2)\n",
+      "Requirement already satisfied: prometheus-client in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.7.1)\n",
+      "Requirement already satisfied: pyzmq>=17 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (18.0.2)\n",
+      "Requirement already satisfied: wcwidth in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from prompt-toolkit<2.1.0,>=2.0.0->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.1.7)\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pexpect; sys_platform != \"win32\"->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.6.0)\n",
+      "Requirement already satisfied: parso>=0.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jedi>=0.10->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.5.0)\n",
       "Requirement already satisfied: testpath in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.4.2)\n",
-      "Requirement already satisfied: mistune>=0.8.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.8.4)\n",
+      "Requirement already satisfied: pandocfilters>=1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (1.4.2)\n",
       "Requirement already satisfied: entrypoints>=0.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.3)\n",
+      "Requirement already satisfied: bleach in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (3.1.0)\n",
+      "Requirement already satisfied: mistune>=0.8.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.8.4)\n",
+      "Requirement already satisfied: defusedxml in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.5.0)\n",
       "Requirement already satisfied: webencodings in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.5.1)\n"
      ]
     }
    ],
    "source": [
+    "#!pip install git+https://github.com/dtip/datacube-utilities.git#egg=datacube_utilities\n",
     "!pip install git+https://github.com/SatelliteApplicationsCatapult/datacube-utilities.git#egg=datacube_utilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: xarray==0.13.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (0.13.0)\n",
+      "Requirement already satisfied: numpy>=1.12 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from xarray==0.13.0) (1.16.4)\n",
+      "Requirement already satisfied: pandas>=0.19.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from xarray==0.13.0) (0.24.2)\n",
+      "Requirement already satisfied: pytz>=2011k in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pandas>=0.19.2->xarray==0.13.0) (2019.1)\n",
+      "Requirement already satisfied: python-dateutil>=2.5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pandas>=0.19.2->xarray==0.13.0) (2.8.0)\n",
+      "Requirement already satisfied: six>=1.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from python-dateutil>=2.5.0->pandas>=0.19.2->xarray==0.13.0) (1.12.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# We seem to be hitting an old xarray bug using v0.12.1. See https://github.com/pydata/xarray/issues/3171 and https://github.com/pydata/xarray/pull/3173\n",
+    "# We want at least xarray version 0.13.0\n",
+    "#!pip install xarray --upgrade\n",
+    "#!pip install dask --upgrade\n",
+    "#!pip uninstall -y xarray dask\n",
+    "#!pip install xarray==0.13.0\n",
+    "#!pip install blosc==1.8.1 pandas==0.24.2"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.13.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'scheduler': {'host': (('python', '3.6.7.final.0'),\n",
+       "   ('python-bits', 64),\n",
+       "   ('OS', 'Linux'),\n",
+       "   ('OS-release', '4.15.0-55-generic'),\n",
+       "   ('machine', 'x86_64'),\n",
+       "   ('processor', ''),\n",
+       "   ('byteorder', 'little'),\n",
+       "   ('LC_ALL', 'C.UTF-8'),\n",
+       "   ('LANG', 'C.UTF-8'),\n",
+       "   ('LOCALE', 'en_US.UTF-8')),\n",
+       "  'packages': {'required': (('dask', '2.0.0'),\n",
+       "    ('distributed', '2.0.1'),\n",
+       "    ('msgpack', '0.6.1'),\n",
+       "    ('cloudpickle', '1.2.1'),\n",
+       "    ('tornado', '6.0.3'),\n",
+       "    ('toolz', '0.9.0')),\n",
+       "   'optional': (('numpy', '1.16.4'),\n",
+       "    ('pandas', '0.24.2'),\n",
+       "    ('bokeh', '1.2.0'),\n",
+       "    ('lz4', None),\n",
+       "    ('dask_ml', None),\n",
+       "    ('blosc', '1.8.1'))}},\n",
+       " 'workers': {'tcp://10.244.1.72:41713': {'host': (('python', '3.6.7.final.0'),\n",
+       "    ('python-bits', 64),\n",
+       "    ('OS', 'Linux'),\n",
+       "    ('OS-release', '4.15.0-55-generic'),\n",
+       "    ('machine', 'x86_64'),\n",
+       "    ('processor', ''),\n",
+       "    ('byteorder', 'little'),\n",
+       "    ('LC_ALL', 'C.UTF-8'),\n",
+       "    ('LANG', 'C.UTF-8'),\n",
+       "    ('LOCALE', 'en_US.UTF-8')),\n",
+       "   'packages': {'required': (('dask', '2.0.0'),\n",
+       "     ('distributed', '2.0.1'),\n",
+       "     ('msgpack', '0.6.1'),\n",
+       "     ('cloudpickle', '1.2.1'),\n",
+       "     ('tornado', '6.0.3'),\n",
+       "     ('toolz', '0.9.0')),\n",
+       "    'optional': (('numpy', '1.16.4'),\n",
+       "     ('pandas', '0.24.2'),\n",
+       "     ('bokeh', '1.2.0'),\n",
+       "     ('lz4', None),\n",
+       "     ('dask_ml', None),\n",
+       "     ('blosc', '1.8.1'))}},\n",
+       "  'tcp://10.244.2.109:38699': {'host': (('python', '3.6.7.final.0'),\n",
+       "    ('python-bits', 64),\n",
+       "    ('OS', 'Linux'),\n",
+       "    ('OS-release', '4.15.0-55-generic'),\n",
+       "    ('machine', 'x86_64'),\n",
+       "    ('processor', ''),\n",
+       "    ('byteorder', 'little'),\n",
+       "    ('LC_ALL', 'C.UTF-8'),\n",
+       "    ('LANG', 'C.UTF-8'),\n",
+       "    ('LOCALE', 'en_US.UTF-8')),\n",
+       "   'packages': {'required': (('dask', '2.0.0'),\n",
+       "     ('distributed', '2.0.1'),\n",
+       "     ('msgpack', '0.6.1'),\n",
+       "     ('cloudpickle', '1.2.1'),\n",
+       "     ('tornado', '6.0.3'),\n",
+       "     ('toolz', '0.9.0')),\n",
+       "    'optional': (('numpy', '1.16.4'),\n",
+       "     ('pandas', '0.24.2'),\n",
+       "     ('bokeh', '1.2.0'),\n",
+       "     ('lz4', None),\n",
+       "     ('dask_ml', None),\n",
+       "     ('blosc', '1.8.1'))}},\n",
+       "  'tcp://10.244.3.103:40397': {'host': (('python', '3.6.7.final.0'),\n",
+       "    ('python-bits', 64),\n",
+       "    ('OS', 'Linux'),\n",
+       "    ('OS-release', '4.15.0-55-generic'),\n",
+       "    ('machine', 'x86_64'),\n",
+       "    ('processor', ''),\n",
+       "    ('byteorder', 'little'),\n",
+       "    ('LC_ALL', 'C.UTF-8'),\n",
+       "    ('LANG', 'C.UTF-8'),\n",
+       "    ('LOCALE', 'en_US.UTF-8')),\n",
+       "   'packages': {'required': (('dask', '2.0.0'),\n",
+       "     ('distributed', '2.0.1'),\n",
+       "     ('msgpack', '0.6.1'),\n",
+       "     ('cloudpickle', '1.2.1'),\n",
+       "     ('tornado', '6.0.3'),\n",
+       "     ('toolz', '0.9.0')),\n",
+       "    'optional': (('numpy', '1.16.4'),\n",
+       "     ('pandas', '0.24.2'),\n",
+       "     ('bokeh', '1.2.0'),\n",
+       "     ('lz4', None),\n",
+       "     ('dask_ml', None),\n",
+       "     ('blosc', '1.8.1'))}},\n",
+       "  'tcp://10.244.4.91:35177': {'host': (('python', '3.6.7.final.0'),\n",
+       "    ('python-bits', 64),\n",
+       "    ('OS', 'Linux'),\n",
+       "    ('OS-release', '4.15.0-55-generic'),\n",
+       "    ('machine', 'x86_64'),\n",
+       "    ('processor', ''),\n",
+       "    ('byteorder', 'little'),\n",
+       "    ('LC_ALL', 'C.UTF-8'),\n",
+       "    ('LANG', 'C.UTF-8'),\n",
+       "    ('LOCALE', 'en_US.UTF-8')),\n",
+       "   'packages': {'required': (('dask', '2.0.0'),\n",
+       "     ('distributed', '2.0.1'),\n",
+       "     ('msgpack', '0.6.1'),\n",
+       "     ('cloudpickle', '1.2.1'),\n",
+       "     ('tornado', '6.0.3'),\n",
+       "     ('toolz', '0.9.0')),\n",
+       "    'optional': (('numpy', '1.16.4'),\n",
+       "     ('pandas', '0.24.2'),\n",
+       "     ('bokeh', '1.2.0'),\n",
+       "     ('lz4', None),\n",
+       "     ('dask_ml', None),\n",
+       "     ('blosc', '1.8.1'))}},\n",
+       "  'tcp://10.244.5.72:36379': {'host': (('python', '3.6.7.final.0'),\n",
+       "    ('python-bits', 64),\n",
+       "    ('OS', 'Linux'),\n",
+       "    ('OS-release', '4.15.0-55-generic'),\n",
+       "    ('machine', 'x86_64'),\n",
+       "    ('processor', ''),\n",
+       "    ('byteorder', 'little'),\n",
+       "    ('LC_ALL', 'C.UTF-8'),\n",
+       "    ('LANG', 'C.UTF-8'),\n",
+       "    ('LOCALE', 'en_US.UTF-8')),\n",
+       "   'packages': {'required': (('dask', '2.0.0'),\n",
+       "     ('distributed', '2.0.1'),\n",
+       "     ('msgpack', '0.6.1'),\n",
+       "     ('cloudpickle', '1.2.1'),\n",
+       "     ('tornado', '6.0.3'),\n",
+       "     ('toolz', '0.9.0')),\n",
+       "    'optional': (('numpy', '1.16.4'),\n",
+       "     ('pandas', '0.24.2'),\n",
+       "     ('bokeh', '1.2.0'),\n",
+       "     ('lz4', None),\n",
+       "     ('dask_ml', None),\n",
+       "     ('blosc', '1.8.1'))}}},\n",
+       " 'client': {'host': [('python', '3.6.7.final.0'),\n",
+       "   ('python-bits', 64),\n",
+       "   ('OS', 'Linux'),\n",
+       "   ('OS-release', '4.15.0-55-generic'),\n",
+       "   ('machine', 'x86_64'),\n",
+       "   ('processor', 'x86_64'),\n",
+       "   ('byteorder', 'little'),\n",
+       "   ('LC_ALL', 'en_US.UTF-8'),\n",
+       "   ('LANG', 'en_US.UTF-8'),\n",
+       "   ('LOCALE', 'en_US.UTF-8')],\n",
+       "  'packages': {'required': [('dask', '2.0.0'),\n",
+       "    ('distributed', '2.0.1'),\n",
+       "    ('msgpack', '0.6.1'),\n",
+       "    ('cloudpickle', '1.2.1'),\n",
+       "    ('tornado', '6.0.3'),\n",
+       "    ('toolz', '0.9.0')],\n",
+       "   'optional': [('numpy', '1.16.4'),\n",
+       "    ('pandas', '0.24.2'),\n",
+       "    ('bokeh', '1.2.0'),\n",
+       "    ('lz4', None),\n",
+       "    ('dask_ml', None),\n",
+       "    ('blosc', '1.8.1')]}}}"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Magic + imports likely common across all notebooks\n",
     "%load_ext autoreload\n",
@@ -178,8 +378,17 @@
     "from matplotlib.cm import RdYlGn, Greens\n",
     "\n",
     "import dask\n",
+    "from dask.distributed import Client\n",
     "\n",
-    "CMAP = \"Blues\""
+    "import odc.algo\n",
+    "\n",
+    "CMAP = \"Blues\"\n",
+    "\n",
+    "print(xr.__version__)\n",
+    "\n",
+    "client = Client('dask-scheduler.dask.svc.cluster.local:8786')\n",
+    "#client = Client(n_workers=2, threads_per_worker=2, memory_limit='1GB')\n",
+    "client.get_versions(check=True)"
    ]
   },
   {
@@ -223,9 +432,21 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Datacube<index=Index<db=PostgresDb<engine=Engine(postgresql://postgres:***@datacubedb-postgresql.datacubedb.svc.cluster.local:5432/datacube)>>>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "dc = datacube.Datacube(app='ndvi anomoly')"
+    "dc = datacube.Datacube(app='ndvi anomoly')\n",
+    "dc"
    ]
   },
   {
@@ -286,8 +507,18 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 22.4 ms, sys: 3.11 ms, total: 25.5 ms\n",
+      "Wall time: 28.6 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "lat_extents, lon_extents = create_lat_lon(aoi_wkt)"
    ]
   },
@@ -299,22 +530,18 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div style=\"width:100%;\"><div style=\"position:relative;width:100%;height:0;padding-bottom:60%;\"><iframe src=\"data:text/html;charset=utf-8;base64,PCFET0NUWVBFIGh0bWw+CjxoZWFkPiAgICAKICAgIDxtZXRhIGh0dHAtZXF1aXY9ImNvbnRlbnQtdHlwZSIgY29udGVudD0idGV4dC9odG1sOyBjaGFyc2V0PVVURi04IiAvPgogICAgCiAgICAgICAgPHNjcmlwdD4KICAgICAgICAgICAgTF9OT19UT1VDSCA9IGZhbHNlOwogICAgICAgICAgICBMX0RJU0FCTEVfM0QgPSBmYWxzZTsKICAgICAgICA8L3NjcmlwdD4KICAgIAogICAgPHNjcmlwdCBzcmM9Imh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vbGVhZmxldEAxLjQuMC9kaXN0L2xlYWZsZXQuanMiPjwvc2NyaXB0PgogICAgPHNjcmlwdCBzcmM9Imh0dHBzOi8vY29kZS5qcXVlcnkuY29tL2pxdWVyeS0xLjEyLjQubWluLmpzIj48L3NjcmlwdD4KICAgIDxzY3JpcHQgc3JjPSJodHRwczovL21heGNkbi5ib290c3RyYXBjZG4uY29tL2Jvb3RzdHJhcC8zLjIuMC9qcy9ib290c3RyYXAubWluLmpzIj48L3NjcmlwdD4KICAgIDxzY3JpcHQgc3JjPSJodHRwczovL2NkbmpzLmNsb3VkZmxhcmUuY29tL2FqYXgvbGlicy9MZWFmbGV0LmF3ZXNvbWUtbWFya2Vycy8yLjAuMi9sZWFmbGV0LmF3ZXNvbWUtbWFya2Vycy5qcyI+PC9zY3JpcHQ+CiAgICA8bGluayByZWw9InN0eWxlc2hlZXQiIGhyZWY9Imh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vbGVhZmxldEAxLjQuMC9kaXN0L2xlYWZsZXQuY3NzIi8+CiAgICA8bGluayByZWw9InN0eWxlc2hlZXQiIGhyZWY9Imh0dHBzOi8vbWF4Y2RuLmJvb3RzdHJhcGNkbi5jb20vYm9vdHN0cmFwLzMuMi4wL2Nzcy9ib290c3RyYXAubWluLmNzcyIvPgogICAgPGxpbmsgcmVsPSJzdHlsZXNoZWV0IiBocmVmPSJodHRwczovL21heGNkbi5ib290c3RyYXBjZG4uY29tL2Jvb3RzdHJhcC8zLjIuMC9jc3MvYm9vdHN0cmFwLXRoZW1lLm1pbi5jc3MiLz4KICAgIDxsaW5rIHJlbD0ic3R5bGVzaGVldCIgaHJlZj0iaHR0cHM6Ly9tYXhjZG4uYm9vdHN0cmFwY2RuLmNvbS9mb250LWF3ZXNvbWUvNC42LjMvY3NzL2ZvbnQtYXdlc29tZS5taW4uY3NzIi8+CiAgICA8bGluayByZWw9InN0eWxlc2hlZXQiIGhyZWY9Imh0dHBzOi8vY2RuanMuY2xvdWRmbGFyZS5jb20vYWpheC9saWJzL0xlYWZsZXQuYXdlc29tZS1tYXJrZXJzLzIuMC4yL2xlYWZsZXQuYXdlc29tZS1tYXJrZXJzLmNzcyIvPgogICAgPGxpbmsgcmVsPSJzdHlsZXNoZWV0IiBocmVmPSJodHRwczovL3Jhd2Nkbi5naXRoYWNrLmNvbS9weXRob24tdmlzdWFsaXphdGlvbi9mb2xpdW0vbWFzdGVyL2ZvbGl1bS90ZW1wbGF0ZXMvbGVhZmxldC5hd2Vzb21lLnJvdGF0ZS5jc3MiLz4KICAgIDxzdHlsZT5odG1sLCBib2R5IHt3aWR0aDogMTAwJTtoZWlnaHQ6IDEwMCU7bWFyZ2luOiAwO3BhZGRpbmc6IDA7fTwvc3R5bGU+CiAgICA8c3R5bGU+I21hcCB7cG9zaXRpb246YWJzb2x1dGU7dG9wOjA7Ym90dG9tOjA7cmlnaHQ6MDtsZWZ0OjA7fTwvc3R5bGU+CiAgICAKICAgICAgICAgICAgPG1ldGEgbmFtZT0idmlld3BvcnQiIGNvbnRlbnQ9IndpZHRoPWRldmljZS13aWR0aCwKICAgICAgICAgICAgICAgIGluaXRpYWwtc2NhbGU9MS4wLCBtYXhpbXVtLXNjYWxlPTEuMCwgdXNlci1zY2FsYWJsZT1ubyIgLz4KICAgICAgICAgICAgPHN0eWxlPgogICAgICAgICAgICAgICAgI21hcF9iMWRhMTI2ZTNmNmM0YmQzYjVhMTdlMzM0ZWNhNTRlZiB7CiAgICAgICAgICAgICAgICAgICAgcG9zaXRpb246IHJlbGF0aXZlOwogICAgICAgICAgICAgICAgICAgIHdpZHRoOiAxMDAuMCU7CiAgICAgICAgICAgICAgICAgICAgaGVpZ2h0OiAxMDAuMCU7CiAgICAgICAgICAgICAgICAgICAgbGVmdDogMC4wJTsKICAgICAgICAgICAgICAgICAgICB0b3A6IDAuMCU7CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIDwvc3R5bGU+CiAgICAgICAgCjwvaGVhZD4KPGJvZHk+ICAgIAogICAgCiAgICAgICAgICAgIDxkaXYgY2xhc3M9ImZvbGl1bS1tYXAiIGlkPSJtYXBfYjFkYTEyNmUzZjZjNGJkM2I1YTE3ZTMzNGVjYTU0ZWYiID48L2Rpdj4KICAgICAgICAKPC9ib2R5Pgo8c2NyaXB0PiAgICAKICAgIAogICAgICAgICAgICB2YXIgbWFwX2IxZGExMjZlM2Y2YzRiZDNiNWExN2UzMzRlY2E1NGVmID0gTC5tYXAoCiAgICAgICAgICAgICAgICAibWFwX2IxZGExMjZlM2Y2YzRiZDNiNWExN2UzMzRlY2E1NGVmIiwKICAgICAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICAgICBjZW50ZXI6IFstMTcuNjI3NTYzNDc2NTYyLCAxNzkuMDA5NTEzODU0OTldLAogICAgICAgICAgICAgICAgICAgIGNyczogTC5DUlMuRVBTRzM4NTcsCiAgICAgICAgICAgICAgICAgICAgem9vbTogMTMsCiAgICAgICAgICAgICAgICAgICAgem9vbUNvbnRyb2w6IHRydWUsCiAgICAgICAgICAgICAgICAgICAgcHJlZmVyQ2FudmFzOiBmYWxzZSwKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgKTsKCiAgICAgICAgICAgIAoKICAgICAgICAKICAgIAogICAgICAgICAgICB2YXIgdGlsZV9sYXllcl82M2QwMTQwYjViM2U0ZmQzYTkzMDgyNmY0ZTRkNmIxYyA9IEwudGlsZUxheWVyKAogICAgICAgICAgICAgICAgIiBodHRwOi8vbXQxLmdvb2dsZS5jb20vdnQvbHlycz15XHUwMDI2ej17en1cdTAwMjZ4PXt4fVx1MDAyNnk9e3l9IiwKICAgICAgICAgICAgICAgIHsiYXR0cmlidXRpb24iOiAiR29vZ2xlIiwgImRldGVjdFJldGluYSI6IGZhbHNlLCAibWF4TmF0aXZlWm9vbSI6IDE4LCAibWF4Wm9vbSI6IDE4LCAibWluWm9vbSI6IDAsICJub1dyYXAiOiBmYWxzZSwgIm9wYWNpdHkiOiAxLCAic3ViZG9tYWlucyI6ICJhYmMiLCAidG1zIjogZmFsc2V9CiAgICAgICAgICAgICkuYWRkVG8obWFwX2IxZGExMjZlM2Y2YzRiZDNiNWExN2UzMzRlY2E1NGVmKTsKICAgICAgICAKICAgIAogICAgICAgICAgICB2YXIgcG9seV9saW5lX2EyNjgyMWNmYjM4NDQwODdiYmIzZDQ5MTU2NTg5YWU5ID0gTC5wb2x5bGluZSgKICAgICAgICAgICAgICAgIFtbLTE3LjY2MjU4MjM5NzQ2LCAxNzguOTc5OTg4MDk4MTVdLCBbLTE3LjY2MjU4MjM5NzQ2LCAxNzkuMDM5MDM5NjExODNdLCBbLTE3LjU5MjU0NDU1NTY2NCwgMTc5LjAzOTAzOTYxMTgzXSwgWy0xNy41OTI1NDQ1NTU2NjQsIDE3OC45Nzk5ODgwOTgxNV0sIFstMTcuNjYyNTgyMzk3NDYsIDE3OC45Nzk5ODgwOTgxNV1dLAogICAgICAgICAgICAgICAgeyJidWJibGluZ01vdXNlRXZlbnRzIjogdHJ1ZSwgImNvbG9yIjogInJlZCIsICJkYXNoQXJyYXkiOiBudWxsLCAiZGFzaE9mZnNldCI6IG51bGwsICJmaWxsIjogZmFsc2UsICJmaWxsQ29sb3IiOiAicmVkIiwgImZpbGxPcGFjaXR5IjogMC4yLCAiZmlsbFJ1bGUiOiAiZXZlbm9kZCIsICJsaW5lQ2FwIjogInJvdW5kIiwgImxpbmVKb2luIjogInJvdW5kIiwgIm5vQ2xpcCI6IGZhbHNlLCAib3BhY2l0eSI6IDAuOCwgInNtb290aEZhY3RvciI6IDEuMCwgInN0cm9rZSI6IHRydWUsICJ3ZWlnaHQiOiAzfQogICAgICAgICAgICApLmFkZFRvKG1hcF9iMWRhMTI2ZTNmNmM0YmQzYjVhMTdlMzM0ZWNhNTRlZik7CiAgICAgICAgCiAgICAKICAgICAgICAgICAgICAgIHZhciBsYXRfbG5nX3BvcHVwX2VlYzQxZmNiNWM4MTQxZmI5MzcxNGM0MTI0MjJkNmNjID0gTC5wb3B1cCgpOwogICAgICAgICAgICAgICAgZnVuY3Rpb24gbGF0TG5nUG9wKGUpIHsKICAgICAgICAgICAgICAgICAgICBsYXRfbG5nX3BvcHVwX2VlYzQxZmNiNWM4MTQxZmI5MzcxNGM0MTI0MjJkNmNjCiAgICAgICAgICAgICAgICAgICAgICAgIC5zZXRMYXRMbmcoZS5sYXRsbmcpCiAgICAgICAgICAgICAgICAgICAgICAgIC5zZXRDb250ZW50KCJMYXRpdHVkZTogIiArIGUubGF0bG5nLmxhdC50b0ZpeGVkKDQpICsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIjxicj5Mb25naXR1ZGU6ICIgKyBlLmxhdGxuZy5sbmcudG9GaXhlZCg0KSkKICAgICAgICAgICAgICAgICAgICAgICAgLm9wZW5PbihtYXBfYjFkYTEyNmUzZjZjNGJkM2I1YTE3ZTMzNGVjYTU0ZWYpOwogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIG1hcF9iMWRhMTI2ZTNmNmM0YmQzYjVhMTdlMzM0ZWNhNTRlZi5vbignY2xpY2snLCBsYXRMbmdQb3ApOwogICAgICAgICAgICAKPC9zY3JpcHQ+\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
-      ],
-      "text/plain": [
-       "<folium.folium.Map at 0x7f86cf7855c0>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 8 µs, sys: 1 µs, total: 9 µs\n",
+      "Wall time: 17.9 µs\n"
+     ]
     }
    ],
    "source": [
+    "%%time\n",
     "## The code below renders a map that can be used to orient yourself with the region.\n",
-    "display_map(latitude = lat_extents, longitude = lon_extents)"
+    "#display_map(latitude = lat_extents, longitude = lon_extents)"
    ]
   },
   {
@@ -342,8 +569,18 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 253 ms, sys: 34.8 ms, total: 288 ms\n",
+      "Wall time: 291 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "x_A, y_A = transform(inProj, outProj, min_lon, min_lat)\n",
     "x_B, y_B = transform(inProj, outProj, max_lon, max_lat)"
    ]
@@ -405,8 +642,18 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 16 µs, sys: 3 µs, total: 19 µs\n",
+      "Wall time: 27.7 µs\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "baseline_product, baseline_measurement, baseline_water_product = create_product_measurement(platform_base)\n",
     "analysis_product, analysis_measurement, analysis_water_product = create_product_measurement(platform_analysis)"
    ]
@@ -442,11 +689,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(datetime.date(2015, 3, 1), datetime.date(2015, 9, 1))\n"
+      "(datetime.date(2015, 3, 1), datetime.date(2015, 9, 1))\n",
+      "CPU times: user 4.15 ms, sys: 0 ns, total: 4.15 ms\n",
+      "Wall time: 3.73 ms\n"
      ]
     }
    ],
    "source": [
+    "%%time\n",
     "#format dates\n",
     "def createDate(inputStart, inputEnd):\n",
     "    start = datetime.strptime(inputStart, '%Y-%m-%d')\n",
@@ -497,7 +747,33 @@
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:   (time: 12, x: 210, y: 259)\n",
+       "Coordinates:\n",
+       "  * time      (time) datetime64[ns] 2015-03-07T22:06:18 ... 2015-08-30T22:06:26\n",
+       "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
+       "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
+       "Data variables:\n",
+       "    green     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    red       (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    blue      (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    nir       (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    swir1     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    swir2     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    pixel_qa  (time, y, x) uint16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "Attributes:\n",
+       "    crs:      EPSG:3460"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "baseline_ds = dc.load(\n",
     "    time = baseline_time_period,\n",
@@ -505,14 +781,42 @@
     "    product = baseline_product,\n",
     "    measurements = baseline_measurement,\n",
     "    **query\n",
-    ")"
+    ")\n",
+    "\n",
+    "baseline_ds"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:   (time: 12, x: 210, y: 259)\n",
+       "Coordinates:\n",
+       "  * time      (time) datetime64[ns] 2016-03-09T22:06:29 ... 2016-09-01T22:06:49\n",
+       "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
+       "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
+       "Data variables:\n",
+       "    green     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    red       (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    blue      (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    nir       (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    swir1     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    swir2     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    pixel_qa  (time, y, x) uint16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "Attributes:\n",
+       "    crs:      EPSG:3460"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "analysis_ds = dc.load(\n",
     "    time = analysis_time_period,\n",
@@ -520,15 +824,27 @@
     "    product = analysis_product,\n",
     "    measurements = analysis_measurement,\n",
     "    **query\n",
-    ")"
+    ")\n",
+    "\n",
+    "analysis_ds"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 673 ms, sys: 19.6 ms, total: 693 ms\n",
+      "Wall time: 852 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "#load baseline pre-generated water masks\n",
     "if platform_base in [\"LANDSAT_8\", \"LANDSAT_7\", \"LANDSAT_5\", \"LANDSAT_4\"]:   \n",
     "    water_scenes_baseline = dc.load(product=baseline_water_product,\n",
@@ -542,8 +858,18 @@
    "cell_type": "code",
    "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 644 ms, sys: 20.2 ms, total: 665 ms\n",
+      "Wall time: 736 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "#load analysis pre-generated water wasks\n",
     "if platform_analysis in [\"LANDSAT_8\", \"LANDSAT_7\", \"LANDSAT_5\", \"LANDSAT_4\"]:   \n",
     "    water_scenes_analysis = dc.load(product=analysis_water_product,\n",
@@ -650,8 +976,18 @@
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 117 ms, sys: 740 µs, total: 118 ms\n",
+      "Wall time: 126 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "b_good_quality = look_up_clean(platform_base, baseline_ds)\n",
     "a_good_quality = look_up_clean(platform_analysis, analysis_ds)"
    ]
@@ -660,10 +996,41 @@
    "cell_type": "code",
    "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:   (time: 12, x: 210, y: 259)\n",
+       "Coordinates:\n",
+       "  * time      (time) datetime64[ns] 2015-03-07T22:06:18 ... 2015-08-30T22:06:26\n",
+       "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
+       "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
+       "Data variables:\n",
+       "    green     (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    red       (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    blue      (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    nir       (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    swir1     (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    swir2     (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    pixel_qa  (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "Attributes:\n",
+       "    crs:      EPSG:3460"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
+    "\n",
     "baseline_ds = baseline_ds.where(b_good_quality)\n",
-    "analysis_ds = analysis_ds.where(a_good_quality)"
+    "analysis_ds = analysis_ds.where(a_good_quality)\n",
+    "#baseline_ds = odc.algo.keep_good_only(baseline_ds, where=b_good_quality)\n",
+    "#analysis_ds = odc.algo.keep_good_only(analysis_ds, where=a_good_quality)\n",
+    "\n",
+    "baseline_ds"
    ]
   },
   {
@@ -699,10 +1066,27 @@
    "cell_type": "code",
    "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Delayed('create_median_mosaic-2d28ddb4-e7d4-48f7-a672-cd6f2b739ede')"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
+    "\n",
     "baseline_composite = dask.delayed(new_compositor)(baseline_ds, clean_mask = b_good_quality)\n",
-    "analysis_composite = dask.delayed(new_compositor)(analysis_ds, clean_mask = a_good_quality)"
+    "analysis_composite = dask.delayed(new_compositor)(analysis_ds, clean_mask = a_good_quality)\n",
+    "\n",
+    "#baseline_composite = new_compositor(baseline_ds, clean_mask = b_good_quality)\n",
+    "#analysis_composite = new_compositor(analysis_ds, clean_mask = a_good_quality)\n",
+    "\n",
+    "baseline_composite"
    ]
   },
   {
@@ -716,8 +1100,18 @@
    "cell_type": "code",
    "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 23.9 ms, sys: 4 µs, total: 23.9 ms\n",
+      "Wall time: 30.4 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "water_classes_base = water_scenes_baseline.where(water_scenes_baseline >= 0)\n",
     "water_classes_analysis = water_scenes_analysis.where(water_scenes_analysis >= 0)"
    ]
@@ -726,8 +1120,18 @@
    "cell_type": "code",
    "execution_count": 33,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 33.1 ms, sys: 168 µs, total: 33.3 ms\n",
+      "Wall time: 32.3 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "water_composite_base = water_classes_base.water_classification.mean(dim='time')\n",
     "water_composite_analysis = water_classes_analysis.water_classification.mean(dim='time')"
    ]
@@ -736,10 +1140,21 @@
    "cell_type": "code",
    "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 10.5 ms, sys: 0 ns, total: 10.5 ms\n",
+      "Wall time: 17.6 ms\n"
+     ]
+    }
+   ],
    "source": [
-    "baseline_composite = dask.delayed(baseline_composite.copy(deep=True).where((baseline_composite != np.nan) & (water_composite_base == 0)))\n",
-    "analysis_composite = dask.delayed(analysis_composite.copy(deep=True).where((analysis_composite != np.nan) & (water_composite_analysis == 0)))"
+    "%%time\n",
+    "# TODO check this\n",
+    "baseline_composite = baseline_composite.where((baseline_composite != np.nan) & (water_composite_base == 0))\n",
+    "analysis_composite = analysis_composite.where((analysis_composite != np.nan) & (water_composite_analysis == 0))"
    ]
   },
   {
@@ -784,39 +1199,108 @@
    "cell_type": "code",
    "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.23 ms, sys: 0 ns, total: 2.23 ms\n",
+      "Wall time: 2.24 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "#calculate NDVI\n",
-    "ndvi_baseline_composite = dask.delayed(NDVI(baseline_composite))\n",
-    "ndvi_analysis_composite = dask.delayed(NDVI(analysis_composite))"
+    "ndvi_baseline_composite = NDVI(baseline_composite)\n",
+    "ndvi_analysis_composite = NDVI(analysis_composite)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 38,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "#calculate ndvi anomaly\n",
-    "ndvi_anomaly = dask.delayed(ndvi_analysis_composite - ndvi_baseline_composite)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 49.1 s, sys: 22.1 s, total: 1min 11s\n",
-      "Wall time: 1min 25s\n"
+      "0.13.0\n",
+      "2.0.0\n",
+      "CPU times: user 593 µs, sys: 118 µs, total: 711 µs\n",
+      "Wall time: 644 µs\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
+    "#calculate ndvi anomaly\n",
+    "ndvi_anomaly = ndvi_analysis_composite - ndvi_baseline_composite\n",
+    "\n",
+    "print(xr.__version__)\n",
+    "print(dask.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "distributed.protocol.pickle - INFO - Failed to deserialize b'\\x80\\x04\\x95_\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x8c\\x08builtins\\x94\\x8c\\x08KeyError\\x94\\x93\\x94\\x8c\\x11xarray.core.utils\\x94\\x8c\\nReprObject\\x94\\x93\\x94)\\x81\\x94}\\x94\\x8c\\x06_value\\x94\\x8c\\x0c<this-array>\\x94sb\\x85\\x94R\\x94.'\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/pickle.py\", line 61, in loads\n",
+      "    return pickle.loads(x)\n",
+      "AttributeError: 'ReprObject' object has no attribute '__dict__'\n",
+      "distributed.protocol.core - CRITICAL - Failed to deserialize\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/core.py\", line 126, in loads\n",
+      "    value = _deserialize(head, fs, deserializers=deserializers)\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/serialize.py\", line 190, in deserialize\n",
+      "    return loads(header, frames)\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/serialize.py\", line 64, in pickle_loads\n",
+      "    return pickle.loads(b\"\".join(frames))\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/pickle.py\", line 61, in loads\n",
+      "    return pickle.loads(x)\n",
+      "AttributeError: 'ReprObject' object has no attribute '__dict__'\n",
+      "distributed.utils - ERROR - 'ReprObject' object has no attribute '__dict__'\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/utils.py\", line 713, in log_errors\n",
+      "    yield\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/client.py\", line 1130, in _handle_report\n",
+      "    msgs = yield self.scheduler_comm.comm.read()\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/tornado/gen.py\", line 735, in run\n",
+      "    value = future.result()\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/tornado/gen.py\", line 742, in run\n",
+      "    yielded = self.gen.throw(*exc_info)  # type: ignore\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/comm/tcp.py\", line 218, in read\n",
+      "    frames, deserialize=self.deserialize, deserializers=deserializers\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/tornado/gen.py\", line 735, in run\n",
+      "    value = future.result()\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/tornado/gen.py\", line 209, in wrapper\n",
+      "    yielded = next(result)\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/comm/utils.py\", line 85, in from_frames\n",
+      "    res = _from_frames()\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/comm/utils.py\", line 71, in _from_frames\n",
+      "    frames, deserialize=deserialize, deserializers=deserializers\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/core.py\", line 126, in loads\n",
+      "    value = _deserialize(head, fs, deserializers=deserializers)\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/serialize.py\", line 190, in deserialize\n",
+      "    return loads(header, frames)\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/serialize.py\", line 64, in pickle_loads\n",
+      "    return pickle.loads(b\"\".join(frames))\n",
+      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/pickle.py\", line 61, in loads\n",
+      "    return pickle.loads(x)\n",
+      "AttributeError: 'ReprObject' object has no attribute '__dict__'\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# It seems like we hit this issues sometimes when connecting to the cluster https://github.com/dask/distributed/issues/2842\n",
     "ndvi_anomaly_output = ndvi_anomaly.compute()"
    ]
   },
@@ -834,32 +1318,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7f86cefbd7b8>"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgYAAAHkCAYAAABFW+e0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAgAElEQVR4nOy9e5Rld1Xv+51rP2vXrndVd1c/0mnIg0gUlJyoQ89QUTFyRFR8xAfixQuDC47B8KgXPIIoMDxy1MtFQXIBEcz1GhkIErhAiBcUOYeDvAkhwby604/q6nq/du3ae+017x+/OX9z7V0dOp2u6qpKz88YPfautX5rrd9a1d1r/ub8zjmJmeE4juM4jgMAyU5PwHEcx3Gc3YMbBo7jOI7jRNwwcBzHcRwn4oaB4ziO4zgRNwwcx3Ecx4m4YeA4juM4TsQNA8dxHMfZQYjo3UR0joi+/hj7iYj+nIgeJKKvEdF35fbdQkTflH2v3or5uGHgOI7jODvLewDc8i32/ziAa+XPSwG8HQCIqADgbbL/2wD8IhF926VOxg0Dx3Ecx9lBmPnTAOa/xZDnA/gbDvxPAMNENAngZgAPMvPDzNwCcIeMvSTcMHAcx3Gc3c0hACdzP5+SbY+1/ZIoXuoJrgSIyOtG7xDP+s6nAIn+NZVfQ3sDaG2E751s0zG81gIAUH8ZAPDFB2a2e5qO41xeZpl5YqtPSlcNM5rpVp8WmFm7F0Azt+UdzPyOizgDnWcbf4vtl4QbBs6u5vNfehcok5d/J7zw+ew3wV8Wjc5gHQBAA3UgCf9GeK0Rht9zCgBQfvn7LuOMHce5DJzYlrM2U+AFN279eW/7XJOZb7qEM5wCcCT382EAZwCUH2P7JeGhBMdxHMcRKKEt/7MF3AngVyU74XsALDHzFIDPA7iWiI4RURnArTL2knCPgbMr6WT/ZD+Q2K/t4Inj01OgyX1hW7lk42pVGR7GF46OAADSv30hir98+/ZO2HEc5wlCRH8H4AcBjBPRKQCvA1ACAGa+DcBHATwXwIMAGgD+F9mXEtFvALgLQAHAu5n53kudjxsGzq4k4xA+KGY5DYFoDWhiFEglDqiGQSZhtVYbqJZlfLDUW/fOovMPvwYAKLzgPds5bcdx9jhbtMLv4kJBf2b+xQvsZwCveIx9H0UwHLYMDyU4Tx5a7Z2egeM4zp7HPQbOroLXPiDfxGblFGgFMSHSlnymm42Avj6gKZkK5QoAgEaGAACV77sKnRML2zhrx3GeFND2eAz2Gm4YOI7jOI7ghoEbBruajD8Zvkzdh+TgecNLTz5UU6CCw0IZyFa7x9T6gcWz3dtabaApHgX9VDHikRtRnAgZPK3bfgEAUH7Z32/51B3HcZ4MuMZgl8JLdwAAaNWqZGZf+f2dms5lgZel3kBRxIOcFx6Gv6rcXLLxK2vhixoCAHhjo+sT1Yqd49BBAEBhom8LZ+04zpMFAoFo6//sNdww2IX0GgV83/1XrFGQIdtsFLQ2NhsFjeZjGwWl6iajoPPhl2zTnTiO4+xtPJSwC6GhWwEA3PjHsKHWh/a/hNTUaCAUC6Aj14fvksbHS6fDj4dfefkmu1XUhsOnhhDEMEioaKLDuXNh19JKDBNYamICSjvhe70WPvv6w+fiDLC4ItcJx2Wzq9E4KDzvnVt/P47j7D1cfAjADQPHcRzHibhh4IbBroZqPwUAyI7/CUo/ICtkXQ0nBG6vy7hQ4U89Bbz8PtDgz1/eyV4C2em/yP0ghYtUX9BqgFemw3cpZkSTE4B6B4oFO3ZeQg2N8Fyil6BYAHdkvByXDPchPb4YLvHO4KEpv+SOrbkhx3GcPYwbBo7jOI4DeChBcMNgF5NNvT18qdYtBr++HD4pid0G1bMQNQlpC3uBKACcngZGj4bvJfGM5DMSWtKtdFnSFssl8xRUJcMgd888FzwBWvCIjh2O/9hZCyOVSyhdG66Zfe2Brbkhx3GcJwFuGOxmRI2PVgNUGwMAsAgN0VgEFmYAhFADAPDDXw2H3fi6yzvPi6T5pz+9eWPeEADAYiAQJbHKIc+ELA0aGgD2jYaBBREfdtLYbjlWRZT+CfzIKdDEmGzLXacWxInJdcFA6Nz9Gyj86FvDsK+FZ5h8xx8+gTt0HGev4h4DNwwcx3EcB4DUMXDDwA2DXU1ZhIbry+ANEdJJ62E01qK4jhdOAQAKP37b5Z7hRdP5h1+LYQBeF/f/yhpIQwHqKci3I6sPhG0T4iUoFsybsiHhhaQIOrQ/fF8Vz4F6DNSTAID6JFRRqwKzc2G/1ESgoweRPfymsP9c8E6kf/vCcElv2+w4zhXCthU4IqIqEf0bEX2ViO4loj+U7c8gos8S0T1E9GEiGpTtNxPRV+TPV4lok7+ZiO4koq/nfq4Q0d8T0YNE9Dkiujq370VE9ID8eVFu+zEZ+4AcW96uZ+A4juPsIUR8uNV/9hrb6THYAPBsZl4lohKAzxDRxwD8BYDfZuZ/IaIXA/gdAK8F8HUANzFzSkSTAL5KRB9m5hQAiOhnAPQUzcevA1hg5muI6FYAbwLwC0Q0CuB1AG5CaIX9RSK6k5kXZMybmfkOIrpNzvH2bXwOF42KCHndyv+iKaLDVfEctNqWgreHoO/+TvCJkwAAfjj0O0gO7Q8CS6ArTRFAEFj2i6dgVLsrdkxHoN6B8TGgXwSadRnfCamPND0VUx0jxUI8B01OhG39A0EICfMy0L7QobHzsZcBw4MAgML3/rcndvOO4zh7gG0zDJiZYS/ykvxhANcD+LRsvxvAXQBey8yN3OFVGQsAIKI6gP8M4KUA3pcb93wAfyDf3w/grRQKU/8YgLuZeV6OvxvALUR0B4BnA/glOea9cvyuMgziC60cxHHMGTA/FfaJWx2dFCQ1DVjy99u3/woAoPTC//syTvbxoe2UubEAqoRSxcmoVCYsFmKIJBpDa9IjgjPLVNC2yhkDaoXrC79UBVWH4ncA4KUpO06zGGJVxEGgKGELec7h+hJWkHoHanxRqQQMhnEabkie8qqLfg6O4+xu9uIKf6vZ1l4JRFQgoq8AOIfwov4cgmfgJ2XIzwE4khv/3UR0L4B7ALxMvQUA3gDgzwDkjQcAOATgJADI2CUAY/ntwinZNgZgMXde3e44juM4DrZZfMjMHQDPJKJhAB8kohsBvBjAnxPR7wO4E0ArN/5zAJ5ORDcAeK+EHp4G4Bpm/s28hkA4n2nHT2D7JojopQgeisuPVv/TvgFZavn6fcFdToWSVT48JOGFcw8BCIK53SKW4+ZHwhcVC2odhjyNZvSSYDn0Q8C8jCsWAIjIUkWEaSekLALAaKj6iGodqEg4oqOixoVw3EYLpL0V5JlSZcDG52snjEyG75LWSKt2Ta2PQJUgS2nf/itIHw7b+l73kU23tfGWF8gzCF6H6qv+cfO9O46zq9iL3RC3msvSXZGZFwH8M4BbmPl+Zn4OMz8LwN8BeOg84+8DsAbgRgDfC+BZRHQcwGcAXEdE/yxDT0E8DkRUBDAEYD6/XTgM4AyAWQDDMja//Xxzfgcz38TMNz3B23Ycx3H2Ei4+BLCNHgMimgDQZuZFIuoD8CMA3kRE+5j5HBElAF4D4DYZfwzASREfHkXQIhxn5i9ANADiMfgIM/+gXOZOAC8C8FkAPwvgk8zMRHQXgD8iIllO4jkAflf2fUrG3iHHfmi7nsETIZt6u3VLbIR0OnRSoBJi41TIiehmxKY5cgwAUNC4+NS5kBYIoPCC92z7nL8VaSmsrotavbBSA9K0awzPLQD4ZviuRYz2a0EijuNpTMSFzZZpBaQiJPWN2Pla0pK5PiT7VkJHRgCkKYz1cZC2eM5sPlQM+gdW7cKgeBVqA6BF0T3IfJKrJlC+el84xX/6vXDc9Cx4RTw5feEcvB5Ejukdv4rirX/zGE/KcRxnd7CdoYRJhHBAAcEz8T5m/ggRvZKIXiFjPgDgr+X79wN4NRG1AWQAXs7Msxe4xl8BuJ2IHkTwFNwKAMw8T0RvAPB5Gfd6FSICeBWAO4jojQC+LOfYPVTr9qLSKodZZsZCR6v6pSbAEwU/Xf+M8POxNeCRBwEAnU+FxkqFH3rL9s+9B15+H6JTqhDmT7Ux8KCECzSrYrUBzuTXo5UJtUnSQB2QFzj1S/XHdCOEAgALAyRJqAYJAEsh2yFmLiQ5x1g8f9PKKMvcQIkZFfrsExnfbgJ1MRL0uKWVYKQgV2o5zf1eqmJkLIiwstGO4YXKK/+h93E5jrPDeIGjwHZmJXwNwHeeZ/tbAGx6SzHz7QC+ZWCcmY8jhBf05yaCgPF8Y98N4N3n2f4wgJu/9ewdx3Ec58rEKx/uErT1MFHBVq2UW23LClZDCdxpAX0iSNRUPxUj1ifAR6TB0slHAQCdu14OGgmu9eTm/7qt98Kdfwqfsw8BUrGRSjLXcg106NrwfVxEk8tzsR4Bn5Y6AtPBWUSTV4NGRC6iTaPaTbtnbcncagCSahi9Ag0Zs7Bk3oMBWfUnxc0iz+aiVZYs9PzTaG0AAyFcQYNSYTFJgLOzMo9wbV5vI1sJ8yz0BU9HcmyfjKdYjXHjL4I9W7x6GIXnvXPTM3QcZwfw7ooA3DBwHMdxnIgbBm4Y7Di88v7wmYbVPnNnc/W/Sr07Tg4EQeKGFPxZlpWyFDrC9UO28j10EABA9Rr4kVNbP//0E8BqWDVn930lbLv3X8POWp/1RdDqhdwB1UOlQeoLlQS51QDKIR6PqaA/oDETE8Z+CLrCzzIrXjQfUhJRLFixoxFZ0ZdFt7CwZOmNKlrcWAXrM1KPwcqCPec+KXrUkGdb648dLrvuvy3VEwesSBI1JU1SekEkN10XdiQJMHUaAFD6oRgR84JJjuPsKtww2GF4/gQAgMZDZgG31ja1II5CO8D2FYqhhC9gzZTW5EW3eNpecGvirt93GCSVA7P/GV5AvLQCevr1Yb+435OrfvNxzTubCZrN7LMft9LC6qZXmhsmIlRqw2a0qHCwUAakNgBNitv9UGiFjCSJBgE3xAhYmrFwgVZDrFZsm9ZKkOdCfVVgVKoiakghj2QZ8MJyrFEQQxn9YkhMHLF5TD0onzPWEjpV0SKh8LTDcj4x1JYku6TZsqyLo8Fgw/JaaOjkOM6uwD0Gl6mOgeM4juM4ewP3GOw09fHwqavntTlb+Yp3gFemQ21/IJdiV7bvUsOfqpKXXx0EVYM3gath1UrFCnhSqj/PBXd9+j8eQFFW3HQsrHKzf/8jm5uuhmXlm9z0g9Gtz7NB1EhPe7p5AOYlu1REf9g/HkMDaIibP50LvR+AGFLA+nIU5UHvIV+hUKsiamilsQ4MyfNQD8PUOfB6U+5V/lprf4TBujVb0m2N9bh617RCNDfAWvFQWzwPS9ijUAKvzsjzEI9ElsUQBW/I7yIh8wBImIFPSvrk8qpdX7wZKJdsbo7j7CwuPgTghoHjOI7jAPA6BoobBjtMMvYiAEB2TlLWyGLqcaVcriHUiQJYq/V1UltB6wp5PHgEaHB/9DYQWbSICnKspNsV/8PSpjTBzokQxy8cGoziORoIqYbZZz4BOnIgnGNUBH5py+arq2FddY8csflqKmG1L2oAOMbeN+we1NtQlTRAYLMmYXTUHqDeX7kEUl2F3pO2Th6oxznFfgv55ybH0dgIICmdsQ20PDNePG0re/Xo1PqAcUlhzLeBlqJHUfA4IN6QnEAxzmMlA+0PXiPVfiTf8yY4juPsFG4Y7BDaXKgrD1+ZE5e8CvdGM3C+oRIQ8vClHHA8Vj55edpaNku2AyUle7HKJ113fQwr8InTXfPLzq2CBsrd86hWrHbCsrzUVxvAsDY0EmNhTBsRpbFqIUotu7YaKKsSZhi0Bkj8SMhsyO4LoszCDUeBgyLU02dAiYVRlFrV6hZITQEsS9ijXDIxphoBhQKgwsJ4f2XL9NAXt4oby6VYVlnPS0cmgZrce7bUdX5kmYVH9PzjIzFzJJZ3LpdiaMKbtzjODuOhBAAuPnScrSfLLjzGcRxnl+Iegx2iXQqPvqirYHW1zy5Yal1FRHH18VwdA0nrS0pWz78axmvlQzSXwevSN0BX1qNHzWPQlLoAC5b2R0dklS+hhHRqDQVZ8RYOiQBvbBhYl2vofAb7u9MOARM+Lua8EDqmWEVnOFyrqL0Pzj4I9Mn5tM7AvFQSbLdBDVmpy64YYgFsZY+cp6Ahc5RQAZVKuTFy70ODFjYQkSBmF+z6en8aHmm143lYPQFZZs9SwxftdvQoaAMm6pN77x+y+gjyPPihB8APh5oMhV3SKttxrmTcc+eGgeM4juNEPJTghsGOUVJvs7b51dXoWgO0T8R1Kp4b7TetgGoHGgvWf0CJq9wyMNPdYZBrSyBNf8xkhVws2n5ZbRcmwjmpv4TkoAjrJnJiP/ViqAeAEvuuGoempPOVa6Z/UAEhgMKJL4dxKthrtoDVk+F00m650Jcr+qMrcKWvPxZuikWE5pes8qGs+mPBpYRMW6DeGABYWu4+7+iQFY3a0NRIeWZLi3Z+DRVUK8C8CCln5uw8NX2G8vsZFj0BZ6DhIBDV1Mf03x7yTouO4+wq3DDYAbJz7+x2hwMmCMy/hIfshRJfrEOSeQDEMEGsCKiGwXruhadu79V5sL7Al0X0l2X2ElWB3NFw/kKxAIyO2PWBYARsKs3cAtaW7Hz5z7GaiQ81ZNJYAT9wvGtudOywVQSU87O2ZM4ykNYFyHItkLUMtJJ2rB6BzjF/nN6fGiOtdqxuGMMpE2PhvOVifC4qOOTpBdCEGBXjuXLNvUgFRhoaMEPijBhpg3X7HazI76zDj30ux3EuLy4+BODiQ8fppnzptnJMU3Qcx9mDuMdgB6Bqzp2tK8iyiN7KJaAi3xfCKpqLZasSuCbV+jotW4WrNyE2ABo0l/WypkNuAFPHw3ddeQ8PW+qgpvqdnIrnKjzz9WH4l14Tth06YuNjFcLcyl1X4yrgS1ugWlhdx/BFcxUYlqqFkrrHj5yyZksqHFRPxqH9QFme0WouXbC3V4JeEwBpuENX7MVclUi95sJSru6CeCnW10H10a57yR4Oq/1k36D1TVCPQbEQwhSAhQ/6qoA2gFKvUK6yov7++Kv3h/NO2Lwdx9lZvMBRwD0GjuM4juNE3GOwE+RFeQJJNULOifR0xUvVIfMOQFbKSTF0WAQAbWmcSq+A2lguzi46hVITGJBtKqwrlK2lsa6eZeWLhJB94w3d8243bR7au6GZEwaKcI8kDRGFshVk0pXy9Nzm3gCtduxwGFP81B2fMXBuxsZBUhg11VC0CEQUWyDHgks6x7XFWI1Q75P6a1FwGVsmVytRixDFmDcctePG5b50Pkli3gARivLGBqidq4IImFchKcTn15kPv6v01Aocx9k99MqorkTcMNgB0lI5PnheEDW+iPSofwy8IS+LMWl6VKnnKveFI3l9ASQvXSpIRoNegDOA5ApigFBtBNzRbAQV5aVAcTS42bVpkb6Qa1WgJi/MVq4kMecEgIAZJ5TE6oWxvkL++6kz4XO1YWGAQT2/zKtcsjLFefe73rtkFFClEkWNpIr/U2dApVJoZqRGzprUcmi2LFQilQ1poN+aLamuQEMPjabVJVDjbGLUwiaxtkEaGzcpNDQQGjStrMWwhd4LTYzG51X8jzcCADrv/zc4jrM7IAIKXsfAQwlXPL2lhZ8ItAV/jcqlC4+5ALHD4aXQaF54zIXmsbJ24UGO4zi7FPcYXEZ45f3hSyc1F76uvPUFXa51NT7SbXF8/kWuwkUVuaUixOPMXtY6JimCVOCoKYRpK35XzwWKep3OZqOhudpdv0CRVTBJTYbYLnp1xtz56gFgDhUGgS63/qZKg7E9ctNCAzr/dtMqReagitzLiTPdP683bfWuaYiNpjWEUsolMwy0dsIBaYut7aB1HBDmrL0V9PwD9U2CSLr+ujh/rT2h3p3iYc9gcJzdRMHFh+4xcBzHcRzHcI/B5UTTECkBy+qehqRHQTlXo1/j+LKaz5Ah0dW7rs7RZ54CLY6k1ylVLQavQkDKnTez86dyvoLqDmKRIALOSutjlkJEB/fneh6U7VO0DrHQknoTlheAU6e6rkmVMli9AUq1Yl4BnZt6EOo10y4onbSr6yEA4PBBu8Z8mEeM/7fasdhR7AlRLVvxp1zRozju2OGwLZ96qGmT2pK5sQJSgaG0TkZC1qNBRY3a66HdBEuvCZ4KAsbObAPp+0Lr7eLPvxeO4+wcBNcYAG4YXBa48Y/hi758N1aDGHBtzgwEffmlrdgMieSlnWSZifw09KAvXz5PJ7+8EaAGRb50sbr61xZQAECVASvNPDSRO05qJpyRSokTo/H6sRxzZcDOrwaCNnMql6xpkU6tOBgqDAKm1s+y4IofHbKX9bJUHFxaAY3I+SRjAa02UCyA5xatQVL/AFCQdsySWRCbFxUKZkCMjHc/t57skIgYKloPApzF3xXmpdbDaiOct1qxKpUbDVC9Bswvm+bhETGOigULVYgxktRKyGbXQbVL11g4jnOJUPhvZEcuTXQLgLcAKAB4FzP/cc/+3wHwy/JjEcANACaYeZ6IjgNYAdABkDLzTZcyFzcMdghem7vwoAue5NLb+1JlC2LcWyE+zPcweBzw3OLmjRcrpHwso+BiUA9Lnvnlzdu+BW4UOM6VDREVALwNwI8COAXg80R0JzN/Q8cw858A+BMZ/zwAv8nM87nT/BAzz27FfNww2Ga4/XH7oSMvrlytgijYU49Ap2Urb2m0Q+dJ/+PmkqUCqtdBV/HNZQtN5L0E0twoeiQqAzYXGR8bLRXLJryTfgFotYH+7rTJfNgitl2W62QP3GcvzkXxAFQ3rAZBTA9ct9CA9jRQyiWrapgLM5C67gfF+5Cv/6DjNN1y/6TNUeedJDHMwivTdtxiMDh4TbwUIp6k/jGgEcbxQ4+GffWa9ZjQvgzlKlAP3gAqh2M530NCwyiaBllZR3piCY7j7DwE2qlQws0AHmTmhwGAiO4A8HwA33iM8b8I4O+2azIuPnQcx3Gc7WWciL6Q+/PSnv2HAJzM/XxKtm2CiGoAbgGQb8vKAD5BRF88z7kvGvcYbDNUuiV0U4S1TEZSBPXpqrkWt8VjtLVyS1Ly0paJ8dQDkK7b+VSEqOfK0k3CRFAC5o7tB8IqulerIPMgTsCyio8dH2vVzeJDSqx/gnokHv5q2EUEaDtpFRcur4aYP2CCQwAYl38DPW2aaXjAKjuuiJesWDABoM57Zcme0bjE+zVVslg2MSZJT4ZO28zipngH5pes4yL09Nopci52gIxpiGO5Lovq8RioWpEm6QAZeyxkGVg1FHLe5MAgkkZPp03HcXaEbRQfzl4g7n++iz5W69XnAfjvPWGE72PmM0S0D8DdRHQ/M3/6iU7WDQPHcRzHAUR8uCOhhFMAjuR+PgzgzGOMvRU9YQRmPiOf54jogwihCTcMdjPJvpd0/dxMPxq/l2NcPlfwSFfxpF3/FsyjoFqELAOvh9h09D7ovubyZk9A2gIa3YI9biyYd2JZuyqKx6A+YStf1QJQkuvkmNMY9KYral+CyX3AUvAi6D81rvXZ+WRFzSurgMT0kxueGbZpWehOaqJCPW9CQLoUnwOAoCco5OaOXHZEcxlYkjTBmAnBYE01lHPweq6YUuxzIL+DuUXLKNAiSUsrsYhS1Bisr1lxJNUfqCejXIwlp3kuPCuaGEXp6MEwjS9dH4Z/1xvhOM4VxecBXEtExwCcRnj5/1LvICIaAvADAH4lt60fQMLMK/L9OQBefymTccNgB6gWnwvOPgkAaHbCC6iq6YqFomUsqMs/KVrYQCmgu5YAYG74cs22SUiBW2u5FL1m3MdqLGgfgCER5HU2YhggCgdXpkEj4p6Xpk/otMCzj4TvYgRoiiIN9luPAqkpQP01y0CQ89LQoDVAErQ1Na/OWB0AddcniV1DRYj9o6Bqd4aF9p/gViM2aeKF5Xiu6OLXqoblUhxHT70qbBuR+2wsAvIyj2mIaWphkWgMTQBlSf2895ty/orde773AgA+PQ0avqpr3tk33oDk214Lx3EuLyGUcPmvy8wpEf0GgLsQ/nd/NzPfS0Qvk/23ydCfBvAJZs6Xft0P4IMUQiBFAP8PM+dU7xePGwaO4ziOs8Mw80cBfLRn2209P78HwHt6tj0M4BlbORc3DHaK1SByq2pbZFntz/IChgaDK7y0JqtbHQOYFyHLNhUsiu79ViMnUmzZcb3dDzmz/ZpWWM6lBorAj5eOy76SudY1bJAUzVOg4ryyeRp0dU2TE3ad3pTEYgEk7vzs3i+F8bqan5gAqtYKOtxfGwS5l0quP0NvmEOfS9+gdZkUYRGnHbCkYVI5rN5paCBeg/ZdLfOVlMONVUs1XLACTjFMUM2lbPZJSEMKOfFaLmQRUy5zba4lpIJR8cZkjM5n//dwuu/9b3Ac5/LhvRI8XdFxHMdxnBzuMdghaPDnu37mzj8BAIYwgRJJbHwgxM8pbW2u6tdumlegt0xysRyFhirio+qQraBVcLg6Yx4CLb4kY6hYActqmK65Wo6r2TXVc7E2b2WMa7Ky194DWQbaLwWI+vpsjq2e1sZZZitv8SZETcLMDDAqaYGafjhQNq/AipRrbi6DZXWPtggT587F+cS+CVEImKs2qPMdH7PUyJ4UTMzOgafkfHK/NDRoq3ztgwGYvkN0BCS6BQwPmOZCvRV91dg/gQpy7XLRyjk7jnPZ8F4JATcMdglU+BEAQKvz8dhimcQY4OaSNUPSF2K13m0IALnmS3WgHUIVlO9l0JupsL5mAkPdJ0YGtxqW5VDXBkGJ1UdQY6SxZq7yVreAkGfmQ98AAFBxYWMdvCL5/fLy45W1KPrTF2dsYlStmDESmxctWlhkYJ88v5L1MlgTw0AyC7LjU6C+cJ/JD/xwuObGCvDIw/Jd6jWcmwEOyZz0/pbn7N40S0PvaXTQjJXMahHEWgkaAjogz3t5NdZJ4BUJR4wNWhhHz7U6b2ELx3EuG0TkoQR4KMFxHMdxnBzuMdhllDLEsAGnsqqk3Eq9py9B3J+Hs1DZLwcVslhJMXoR+odygj05h6581S0PWJghqdr3dRHMNZqWRqgegzVz76UAACAASURBVChkLMVVu3oJsJpLHczVBYj1ADT9MJ6jEj0okbQFJM2u58GJdXeM6ZXS2hgdBvYFj0ujP3gaatVB8LDs14ZMaadbwKnzBYJAUns8aPhgYByYPmXPAQAOHQT3/j7U45E07Bz6vBtNS3U8F+qZ8NIKqOAeA8fZCXYiXXG34R4Dx3Ecx3Ei7jHYZfDyNKggRXCkyA8o6a5gCHT1Voj7civVqElQzUC6HleusSJgrmphjNnrSjlLu6sb6nn7ghCQl0LsnVfWbMWr05kOqYzJdVfFWLl2IeQ0BVJZDWvhn76qVRzUe5C4Pxpr1iVRO0AO7rciUFqgqVyL3gzVDGhqIB0YBh09CgCoFeQ+187GYk4kHgbUa+admM1pC4CQjjgsmgERhSJtxXuPOoWps8CoPEN9LnqOQStSpdoLPj1tegLtwdBsberZ4DjO9kPwdEXADYPdR3MZ6YHruzYVkZgLX0MKnJlB0NswKSeE021Uqsbx2s4Z7aZlJRR6/iqsL+fCC3Kds+fA2qBI6gfQ0ICVFq5qeWd9MbOp/+WlSuNjVmVRMxXW1x9bSJlr66wGEzqphVJ0X20k1lagMX2By4t44oCVSZ6TKo2UgIZD4yZel8yD+eVYzjjWX5ASxqj1xcyDWEY6y6x+gYgreX0dOCHGhd67Po/1ZjQStPIhDQ1Y1Uc1IMpF0LXBkMm+8vsAgOSZl1Th1HGcxwN5VgLgoQTHcRzHcXK4x2CXQfuuBUNc4MilF+Y9BYD9DNjKXvcB5mHIcitvWZXHFS8lUYgYvQizmvuf2rHaZKjdBp2T6oYHVCRYjit0ZqlnoJUNy7m/XurNWFsK7nP0pCRqKmKPyJJGjpgQMhfmIG3cJOEObq2ZEFHEhHRI+hyUa/EZRS+B3i9g4YD1dZB4MUj7OWgYQ+sb5I/tpBYq0bTPvmquL4R4RHQe80uAbtOmS+WS9VtVF2a1YtUQPW3RcS4bXscg4B4Dx3Ecx3Ei7jHYbRTKKIrBqv0DgGxzhcJOanF5XWXnV9u6r5DzJvTE8Skp5jwLcqyK4qbngLNSjKcdPAA0OQYMyspeBXt5JJYeU/IG66YZmA5tnXluwVbD8xLbHx82z4WKClX4SAlSDnMrqg4iScArweuAFenZ0G+dFWP8XrwD4Tl0axcoKVm/h3yLZfVyaA+Gpgg1O+fsXk5Lm/R9o6aTiPqAEiiKDeVZ6XGDdWAgiDej5mHxtHlT5qdtvqpd0Lk5jrPtBPHhTs9i53HDYLfRaYH0BS6fXCiakaB1B/JNlHpJW/YyUhqLm8bz8hSwtrmlcUQzBSTLAK22vah0X7FgjYf0uH3ids/PQcIL1F8DhiQ0oPUAzs2D1dDQ+5SXKvctoahGkc5tbd6MIA1zPHrS3Pn7QphDazlQdcDCLE2pq9BeBx59KHzXDIDhARMMaovlhVBFkYYGgYMHw75DB3P3JWGIlVwXVA1baFaEGgE0F0SdsBAIOIsZJKy/n6Wz3caK4ziXDQ8leCjBcRzHcZwc2+YxIKIqgE8DqMh13s/MryOiZwC4DUAdwHEAv8zMy0R0M4B36OEA/oCZPyjn+jiASTnPvwJ4BTN3iKgC4G8APAvAHIBfYObjcsyLALxGzvdGZn6vbD8G4A4AowC+BOCFzNzToWgHWZsHDx0AAJBo+ZgzE9tp9UIq2Io860lX7KTddQ6A4Eov9IxvN4MgDpae15W3L6tn2i9NjFYblpooK2kUCyby0zx/XeU2160Xw9XXxPuDNA2Kef7DA5vmQVr5cPkcWFblMTTQNwhoLYaieBrSFPK4QMvLXffJaRNUk7oO6jmYn7JnMy7u/bFha/GsHgx5BryxATo7ZfMFghekkqvFAIiQUp6ztq1WseL8vD0j9fx0UqtNoZ+14fg8kpv/KxzHuTx4r4TAdnoMNgA8m5mfAeCZAG4hou8B8C4Ar2bmbwfwQQC/I+O/DuAmZn4mgFsA/F9EpG+3n5fz3AhgAsDPyfZfB7DAzNcAeDOANwEAEY0CeB2A7wZwM4DXEZG83fAmAG9m5msBLMg5HMdxHMfBNnoMOOSuaZH7kvxhANcjeBIA4G4AdwF4LTPnVVZVGavnWs7Nt5zb93wAfyDf3w/grUREAH4MwN3MPA8ARHQ3gmFyB4BnA/glOea9cvzbL+1utw4a/qXYglk1BgkSsAoGtRpivhWzivKyXLqi7lOvQqXWvR8A+gbBPNN9rKTRUaEA7uR0AQC41bb0vAER1tVrlp6o89ho2Dm186LuW2uYnkFT8arlzR4LtdqXlqOHIT6Dcj8wczLsHw9eBBqZBBZkRd8Qb4IUKwIlYPWWaDvq09Mxjh89HrX+sKoHTGugKZiN9XD/AEjbTBcL5h3RjouVinlE5K8/TwdBJRVyXh5NvZxdBKuGQj+zNKZ0Oo5z+fB0xcC2ig8p9J/9IoBrALyNmT9HRF8H8JMAPoSw8j+SG//dAN4N4CiCiz/N7bsLYfX/MQQjAAAOATgJAMycEtESgLH8duGUbBsDsJg7r27fXYgLvC3vnBKK5ibX0sXFnGHQ27QnSy3kIDULkGXghij+9bilRXtJa9hAjACkHUBe1pxXxquLX1/qrbYZFXresrjVV+etVbGo+3lpBVgMdh6NiROn1gca0VoFKirkuC/Ocep4OMf+q4B6cOdTsSJznDFj4tBTup/H6qyVOlYDJe3Yy1+zB5rrdl35jILGQ4M2flaMi4VVkD6HWk7YqcbNarjn2CAqSYBz8sJX0eRaAxSFkWL/rq+Bbngq+MRpOI7jXG62VXzIzB0JDRwGcDMR3QjgxQBeQURfBDAAoJUb/zlmfjqA/wDgd0WnoPt+DEFnUEFY9QM5IXz+sk9g+yaI6KVE9AUi+sIFbtNxthw3ChxnZygkW/9nr3FZ0hWZeZGI/hnALcz8pwCeAwBEdB2A/3Se8fcR0RqCpuALue1NIroTIYRwN8KK/wiAU6JHGAIwL9t/MHfKwwD+GcAsgGEiKorX4DCAM48x53dAxJBEdF7jYbug0i0AgIw/GeYCoN0JYrWCyC6KnRS8EJwiNHp080nUZd6UlfLM2bBaB2J1P56Z21zPX8MG6+vmitcx1UpsB6zV/QCARICXHP2tMO/73xh21PpMzJevoqiCPukRQPNL5oHQVb+uwGvDwPKJ8F1X4mNNq4ao1RyHDm1uCKVNldImsLbYfQ51/QN2n0nSLb4ELEySdqK3hCWVEbU+ezaV3PkkHZMflZe7eE1oYtREjRqSufqwNbp6+FGbo87DcZzLBnmvBADb6DEgogkiGpbvfQB+BMD9RLRPtiUIWQO3yc/HVGxIREcRtAjHiahORJOyvQjguQDul8vcCeBF8v1nAXxStA13AXgOEY2I6PA5AO6SfZ+SsZBjP7Rdz8BxHMdx9hrb6TGYBPBe0RkkAN7HzB8holcS0StkzAcA/LV8/34AryaiNoAMwMuZeZaI9gO4U1ITCwA+CTEmAPwVgNuJ6EEET8GtAMDM80T0BgCfl3GvVyEigFcBuIOI3gjgy3KOXQ1zhjQLq9+SiteKZROwSWyaWcSCVDAhm3YObLbiKpQbttqPrY8LPTX5my3wukR55JPqtdgPIabnAdETkZ34MwA5z8GJP7OV/Zo8/iwzMaMUBeJ01VbV+yWtsB6KFFG5H3xgMmxblHOkrVz/BrmXJLGUxKynEmRegzEoqYmLK6Z/0FV/sQDs2999jIoLF2bMO6FixYxjWqF1m5wM1QyRqwCp3pDh/aDxq8K8O9pRsQEsdbd4bt8zhaTeU6DKcZzLgqcrbm9WwtcAfOd5tr8FwFvOs/12ALefZ/s0gubgfNdowlIXe/e9G0HI2Lv9YQQR464nVs7rtNBfEPd4K+fC33ctAFhp3zPHw8+1PmA4vLxoMHxmJ05uEhhyuw3S1sSaX6/nrpbthaaGxGrDXPwaUtjYsIOmQgOmGEqo1q1ugLrfmy0rN6wv5Fbb2h1r6+YD8lIv10AD4R64T4yMfEaGnv/0afBhVWtWbZzSrzUWpOnSRiuKK0nLIJerm1tXz5y1OUoYIBpHRGZcFHLNnGrDwaBJRGioDZiSxAwOnffakhln0mq5pAJPNTocx3EuI14S2XG2mJgJcim4UeA4lx1PVwy4YbCbyVL7rq54TbcrVYGC1BzQlL3J4KZGuwkqicCwKbX+J/cBqZxP8/HTkq3a9byxEVMRNCSNjRq5/gyKiueq1rwopv2J+I8GJ+Mu3hc8ApQkdqx8crEAnFPXunyqaLKeWu+BgtxnlgHc7B6XsXkINLyg4ZRWw74LNDFq19IUxWYLaJwK3yVFM4osW+3NQs1vvwHoE09E9DCcAetzPnC4e1+z0dUjIcyx0u3ZgAgSj4XfZfbom+X64ZrJNa+G4zjbA9HezCLYavwROI7jOI4TcY/BbiZfQz+2US7bNl11qlAv3wNBYuWk8e1cOl9sbbxg1fX43x8MXzTefeSQrYyruQI9Sl6w1+yuWkgHQs0qqv4EOP1E+K56iEodOC3ph5oKmCTxGrHAkrY75lwXSZLrrM2ZV6CZW23PnkMXNUmVXF41bUT0SLRiumRXN0S9r1ERDj60FMfwjKQ8tkX70Vy31MgZyXpNUysCpb8/FYkWy9byWitYZpZ2itqwjVfPjfak6K1a6TjONkAeSoAbBrubqK4/T4+nSu2xKx8WzqNoL1Xj+WIb4PVlewErZ8LLlc/Ogr7r6WG8vuhmF+xlqi/kYiH3MpXQAWvGwMc3GzRJMYYSWMslp53wEk8olmHGnLyERxZAQ93nxcZqNCq0LbKKF2lkyGoUaJy+XjODQI/rdMyQmZyQuclcR/bbtQbn43GkxoUKDhvrQFVCGYOD3c8xHx6ILa2tNgHrczn7qBlIUlExij7rtVgzofDDfwHHcZzLgRsGzu5gC1KEYnrgpTCy/9LPkZ7HkLtY6rULj3EcZ0sJ4sOdnsXO44bBLob6fwYAkM29NwoMo1sdMEEd9/Qq6KQmJiznfsUqfJMPGjsKfuSe8IOGEDRHf9+onb8onovaehAsAibYq5ZD8yEgCh7jtZOieQyiAG+5OyQBhJX9uLjRtS9DkjtOaxasiweg1QZPz3afo14z9796B/Lhjp5QAiUJMBHCLDRxdTj/yrS5/XvqGNBIv81Jz1suAdrieUjmX64B1Z6URD2u0QQGpD/EYgjj8NSMiUJ1XNoB7R+XuYdn2fnUKwEAhR/alOnrOM4WkngowcWHjuM4juMY7jHYAyRjLwI3/jH8EHUHmVUVjANzv85ij86AM1sFq7AtbZlWQFet0vGQ9l9rhZNWZFVcLuVW8rIabrWBRDonVqUXQ/7avQV9VpZs9S4VE5Fl5oGQlEcSq52qQ9YZUQs4LVnVQjoibZfHjm0WVy5KS+lav2kp8qv+cqXrEdHIEfDp+7vvT1s47x+zPgfq5i+WgWXxXKin48A+65ug9y4eFbTadi+iO6CxXGEp1T+0rWOldp3M7nkYjuNsLx5KCLhhsFfQl0zexd1pBVFf1uOKLlQ3jwdMFKgvzpVzwYV/dtYMhLz6fUVeevrSXl0HhnN1C4BgUGRZLDUMwAyPJM0ZI7m4u9RFiO2INXxRr+VesOpKL8cSw3xSqhBWy6AbQ1FNrYqIdjMYRpxZUymtmLg6Y+JHLT/caJquYVCeS2sNmDgC/synLYQg4YauNs35NtOHD4bvpyQrobUR/vQPAWzVG8O9rNixKlZMkk21EEizNrIsziNbylWYdBzH2UbcMNjLnC/74GI5O3vhMRcibxQ8UbZCbMeXntLHn/n0pc+jfwtEkJ6e6DiXH9oSHfSexw2DPQL1/SQASQEEwMUyOuo61xYBLL/OLLWwQv5l2ZtXX64BBw+E858TA0E8B9n/+GRU+dP1YXXOA3PRG0C1YAyE1XhvNT95ySdJdy0GPb/WRZCwBWbmTTCo1RMH9oXPdhP88CPhu4QgaKAO1hRG9UjMnDY3vb5U69qjoGhhhmnxGCyvxiZRybI0c1pYynkDxK0vvSCoVQVLCiU1JBRSLZuXRj0paRqfgz4jhZPEnpV+5pthxR4PHfvfSc5fOBJ+F51/+DUUXvAeOI7jbBduGDiO4zgOXGOguGGwx+Az9wIANg5dD5KkEoasUCmsxItJMVYGZBHCUSe1FbWuTDkD9YdWxawr2JPSK6BYQPZgqMiXHAird6pPRH0Cn82J4VpSBGhcVvmqJ+jAUg1bazK2HfsPkMbsAfMeVEV8KD0YeHUmejFiKuXEQZC2QF4KugNuN60K4ZxUQFyWioLNDWBczp8TTXamw0q9M/Xv4ZavGY9pgrHQkhYnyjL7ri2nMwbk2UPTSQdG7NkvS2VJ7bw4M29piFqRstUAzsk4CafwWiPXi0LSSI9J34VyCdk33gAASL7ttXAcZ2tJPJbghsFeIzn6WwAQsxSa5SKKahDoS49NtEbiws8KRWBgHAkDEDFfrDtQqkbBHqtw8PQUaFKMhpNhPPZLGeJKzYR4jWa4VpbZC1DOj43G5uZM48MgIIQOtOLf6GDYXx+NpYJ5VTIKTj4KGhkCz8wBUi6Z+seA9eUQZmhL1oC+aLPUWkjrNZVqHcl3XR3OvzKNEgDMzoUsBwAol8DMoOueDjr5UBinx2YM2j8OfuQUWA0EzaCYnABqEkpYCZkcfHoaPB0MpuRp4ZpoboBPnAZdc7UZT4vz4bpT50BiGGjzKmQZMDIe5w4AVJTfWaeFbPavw/dzwZhzQ8FxnK3ADYM9TLN8cb++hM+zMV8w6fFQOY9I8GKFcq325m2qBzgPPDO3eaP2SuiaR7p5myIv1i5mN5+Xrnv6Y8/jkVObx2s55fy409ObtsXx11y9efzUuc0Dv9UzPU+JbDcKHOfS8VBCwA2DPQrVfgrc/Ej4QVsQx74ERRMCymfSsWY9sYEPJSZSVA/D+LHw8+Ji6EEKWH8EICeQyzVO0tr+61LvQNs0pyl4LazotS4BnnINqCJhAmkJnYc7shrfkLbHK6smSNSXe6thHgXxFFB1KM6Je1M1m8vxPjWkQQduABeCVyCGNFpt8Ne/Ivcgngh1788tWP0FFUFOjAJDwasSwxdZFhtB0Y0aLpBqi8cO25z0+dWq1uxJXZgjQ9ZsSfpaxN9nllqzpaWpeP7sxJ+FU4hHyXEc54nihoHjOI7jAJ6uKLhhsIdRISKNSUEfXUnmUxSj7iAF9UmK4XqIg1O5P1chUVay+vPkVcBSWJXTslbrawGZuN/VS1CrAn19m68LAKOjoJaspPeFWHlr9BDmmkGDcFD1BGs5l34jpARGd3yWgUrdhYV48XT0AFAS9vHCyRCvByxUoSv8JLHQg3g8eGUamJGCSZqaOLcYuzRGL4VSrVi1QtUA1AeioJNX1uJQrVYYKx6uyjlXG0BN4zkqZOwHXXtD+F6we1LtRPSM6PyTJGpEsCQemmrZtByO4zxhPJQQ8F4JjuM4juNEfJmxh0me8ioAQHb8TwAApPH/cs1WmLqKpyR6FOK4vIiNum1EGtgPjoV3ZMW+sWEeiGVZ0a6tIxrYWlZZCxhlWfQU0PCheO6hcoib8/KCzTF2IpRVcyF4JLjVtqqIOkaLHwGmeSiWrcywzlH7I8wv2ZzKGzZe+i3E1f5qA9lK8DYkNSnkNDAq99kAtBCSaAKouha3RdI0FkKCFFOiAfEclEvmadHUynLNiiStBY8HU2IZFT1aET45bRoOzWJIO0ie9ho4jnPpeHdFNwyeFCRX/w4AgFfeHzZsrNrLMdfQiFVgqNuK5U0vHsvzb1hoQtz7qNZtfzm4xylj66WgaBpilkZxIC9PyWFFlPWlmM8iUMOkIi/6SamdoKmQuXuhYsXSFMV4WRkawWDpqeFaMw+EfX2DNh8VGGpaYbsZKh0CFnoYHUIC2aZGg9ZcqFTAg9JeWns8VPus3oC+rGtVE0lqfQJ9HtUKUB/vvt/pR+PceCYYBjQ0ANTlHLmaEwBC6qaGO84FwyN5/l/BcZy9DRHdAuAtAAoA3sXMf9yz/wcBfAiAlILFB5j59Y/n2IvFDQPHcRzHwc5pDIioAOBtAH4UwCkAnyeiO5n5Gz1D/5WZf+IJHvu4ccPgSQSfEDHiVTeYGE1Xpu1mqH4IIBPPQYdTlBJZ/aqITlstN5ctpW5dUg4nr7FVuJyLK6etY6GujFX0l2XmFWjJirrVjt6G6EIHzDuhjaFqMv/9AD8qBZlGtWpgGaQeDllRD5SHzf0uvRpUmIirvx28IUWMFkIXRJ6eM6FhbKNctO/V7gZV3G6HFT8A3pBKjJyZR0bLO/QNdrd2Rs4TMDxgIZ6FWXseira+bjStyqJef03SN6fm0DkV7qXynz8Ax3G2lh3KSrgZwIPM/DAAENEdAJ4P4PG83C/l2PPi4kPHcRzH2VkOATiZ+/mUbOvle4noq0T0MSLSamyP99jHjXsMnkQkN74OAMDNj1iPBA3/c271Ll4CQmICRPEOUEFWuZwBKz0r6nJtU6vnzr6noijpkvzwl8LGmC7YbwOHDth3FTXmi/b0VGCksqQyAkAy1TXHMECLOcm9NBZt/8qsHQsRPmr/ggdOhM+lNVC/FCrSPg3NDbCs2qmvp+hQ2gFEEBkFhJxt7pZYKNq9jIlOQvUNfbn00CHxkOT6WuCk3GepZNoGKZYUdRztDNzswHGcrYcIKGyP+HCciL6Q+/kdzPyO/KXPc0xvrdovATjKzKtE9FwA/wjg2sd57EXhhsGTEKr+BDj7ZPfGYnnTuGK7FfPkqSwvcX3xV+rAmLx08+2D9aUuRsYGEhSLEl4YlHGN4Oqm+gTSgeD+b6Qh536wUwSkR0OsfEhVc/v3ZEdgfTlmKGBZ8vaHU2vtHG86sXtsiRteqhdy3uWvbv52Zq57CSkwcxQdbvInVsuWdaGGT77fQ1maKJWq9qJXQ6WvP+6Lz1n7VABg7YPwHZZhEa8u804KEsa4dgblMyEc0nlWWBQUfuwv4TjOrmaWmW/6FvtPATiS+/kwgDP5Acy8nPv+USL6SyIafzzHXixuGDiO4ziOsEMag88DuJaIjgE4DeBWAL+UH0BEBwBMMzMT0c0IUoA5AIsXOvZiccPgSQrPSh8AaauMvmFsZGElW1FpCWcgbRfcUzmPKgNAqVvMh0odLP9oVMjYn6XxWuopwJDU968NY70TVuPlgqyG15dNCFgUV351wDwV6oaXnH5wBhw+GL5rL4TmEiDVG6PgsN20e1BPgK7+p84BB6SegjY9Wl61ioci7EOjCYxKHwkRGsZUyVrV2krrfc4vAeMSEqiY4JGXT9t+AJA0R0wMWpqltsBOW+YlyTV6ip0v+3uaS63NxWuS/A/W+e+/jcL3/Skcx9mbMHNKRL8B4C6ElMN3M/O9RPQy2X8bgJ8F8L8RUQpgHcCtzMwAznvspczHDQPHcRzHwc6WRGbmjwL4aM+223Lf3wrgrY/32EvBDYMnKcm+lwAAsjNvAwBQuYbyqqQVDk6GT0qAqugDkp7YfpKaWFFXt60GSFe3WqiHMyuAJGj3RKQtDGg6ZLsVrxm7K3bacRvPSc2OFVlla+x+4oB5BdL1eF7Mi8DwhITSigXQfpmTpPpxpyPzqWxq9UxHD4E3NrquRYf2WxXEXq9Dqw0sTsVrAQhehEHxIqi4cWV6U8tknhIdR9oxT4SSZcCAaDPOnYnXYk35HF3rOj+mzpoHQrs2qgbDcZxLpve/wisRNwye5CQHXwEA4PU7TfiWFxBKFUIqPieMa3887Ms1ROJUXqDzU1YC+NDh8DlzFhjTsscStlChHyWbKyqWa8jU7T4TQhA8Ow8+HV661CcvxBFx6Uv7ZQDWCjkhEwLmGyVpkyUtSay1CPqqQL8YK8uhcRKvNWKdAeqTTIzpWWB4EF2oQZF2YqXEGI4YHIzPkk+ciIfEe9DrT4sRkyR2rBoXzTawJsaQ1klYWQO09oGetJxrJKWlmTkIj/nkNNI7fjWc9ta/geM4zqXghoHjOI7jACCi7UpX3FO4YXCFwFP3gcaPhR/UNV+qWnOeloSn8rUCEnWjy6p9eQ08Jy2b9bwrq6BREciJ9yEthxVzsd0yj4EI65azVZC46etrsrJfbVijIV1Jaw2FYs5Nrj6+RjO600k9Bo0msgdDjY9sKXg4CgelFsJ6EyQhiig0nF0AHQkhFQ05xLBB/rvWEeikoLJs07oOi4vmuRBvBvXXzMtwMNRuIJ13llltB/0dFAvmCZFWz0QEaGtnDT1oZci0E9o3A/E62XwThadOwHEcZytww8BxHMdxhB1KV9xVuGFwhZA85VXIpt4OAKDB/WFjvr1vb2+FNLfaV81Avn9AMVcFcFXS9w6GFW+xldMF9BRWGuwUwaItiCvfZsuEgrpSVr3AyRnQjU/vOgdajdi/IT8fqoR7KIxLx8OJ0a5zAQAdDamP3Gpb2p/Mg1cb1jlRY/r6DCo1E0TqMxoaBDLRB6hXoFa1Vb52kaw1433GuWhqYjsnisx3aBwe7h6n3ptavwkupTBT4duPbBJXOo5z8exkVsJuwg2DKwl9SedDCap21xegGgi5fdQXVPNcnTOxn76IksTEfl+Raov5GgA6Xl++c4v28tdSxOkCoC5+je+pW/2pR+zl2KP2B2DHjY+BxMWvTYswLNdpblhoQOok0P4xE/Fp2KJW3Xx/SqVo149hgLIJGMfkRd5KzYBIz9j19fya6aHGRbFgSxQ1lDLebKjljC0Nu7Ced34phjfa7/nlcJu/9rdwHMd5Irhh4DiO4ziChxLcMLiiSCZ+vetnXrrDvAj6qeLDYhlAtWsfTV5n+f2aQ59L+lVhH+mKed8o+PR0+K4eg4XVGIaIx46NbFrtq3ufjtxgE5aWz7w0FZs/8ZL0ZWi1gfExmWeuuiEQVvX6r11X4IN1YFGOFYEhrzdttT842HVNKvWBdb7qMVheMM/C+USS6n3Qhknn66PQatv4lpy33hdDB5piyuppjMcMggAAIABJREFUqNSBa2ROw6HCIk/PRc9FcizUVeh8+CUoPO+dcBzHuVjcMHAcx3EcqMbAXQZuGFzpFHo8BbqipgRpKewrkvw1ybLulEGBRUBHJRHsqXCvWI7bWHQHNJSZ9wB6KTINgJyXy7Jyb8zZ6ln6BlBtxFbQKlKcngXUe7BfCi2JTgHFsvVg0PsrVU0cuCQVIdcaln44ItfUKo6cmadAuhuiWo76hKibOHR4s15DaTWAZq5IEwBUKjZORJOo1EH1ia5zaMVJ7myASJ6pdLOktGNiRRUpzp5D9jVpwy3PRSn8x/8DjuOcB/JQAuCGwRUNDd0KXnk/AMTGRvpCypIEBepxnWeple/VBkS5l44aCNiQl+vCUq4tcc5oqEmDIAlL8EMno3guZhKoa35tMXcOrXVQtlbQUgaZ02nQiLj/a9bmWMdbfYbM9olBoCWLAYAl2yHWPdAXbbmWqxhpxgipgFINpiQBNsRoanS/kFEsmIAxlc+Bms1TDZ9CJRgX+ToT2nhq+hRYz5Ev16wVLLWl9ZDMoZOC8uMAdD744piR4UaC4zi9uGHgOLsRNRYuBTXoHMd5XHi6YsANgyscGvhZAEC2cHvYkHshdcRdH/+SUK67SL+2Gaa4EuXpOTmnrNjLpeDiB8w/l7FV+lO3fbEQhYIs40h7JRQL0dvAK0HISKNHc7UEgoeDWm3zMmiYQVf4nAWhIGCr7HQuig95Wqo5jg1av4IogpS51qrWK0F6IdBA3cSHuopfmst5D3r+h2m1gbrcl7ayLhRBiXhT9Nknxc2eAm1k1WyZV2NA6yRUrSV1lqtLoeeryNw0/fTQfnTuOQ7HcZzz4YaB4ziO4wiJiw/dMHACycgLu35udz6Boq6C82I6TbfTokCNZkjzAzYXBSoWgocAsJV6uQQsLofTrsjKd/+IFQhSLcL4obBv5Ah4+pvh+/AhO7fOST0H1bKJ+KILXWPxGdAnugZNvewfA6/eG+79KXLe0aFYjKjzhX+Xc4VzJKN9lgapU+h0LG2zt9dD/nnURZjYX43FojQNsqvCZO6TV0X38MiD4VNbStf7rFqitl/uH7bn0NQeEznBpXoR1qUz5r5RJPuCJ6fzD78GACi84D1wHMcB3DBwHoMiEmBNwgDxBZPZ99acDe6pSBjLGzeasQRxfGGurltLZREh0sQoMH6g61qx2mKSRGEdN8TlX+4Ht+Qll3OxI5EX5oCGISTjolAGyjJHERMyd6wyor7AVxvRyEmGctUb9b40+0IzLEql0NI5f3/5ssZiDNGQGB79o5sNmk5qwkh5gXO2Fua+vmznbdu9xfCGGhdJ0c6XP3/aCobcrPyu9olhU6mDnnpVuOSXgwHUeuet4Ea3YVd8ShBDej0E50rBNQaB5MJDnhhEVCWifyOirxLRvUT0h7L9GUT0WSK6h4g+TESDsv1mIvqK/PkqEf20bK8R0f9LRPfLef44d40KEf09ET1IRJ8joqtz+15ERA/Inxflth+TsQ/Isd3F/B3nUqltgXBwffnSz9FuXnjMBXCjwLnSSIi2/M9eYzs9BhsAns3MqxQSrz9DRB8D8BcAfpuZ/4WIXgzgdwC8FsDXAdzEzCkRTQL4KhF9WM71p8z8KXmJ/39E9OPM/DEAvw5ggZmvIaJbAbwJwC8Q0SiA1wG4CSFd/otEdCczL8iYNzPzHUR0m5zj7dv4HPYkVPgR8NoHwg8xZa8M0oqD+7Td8BpIV9W9qYYZ20tSV7QZx6qClF/l6qq5EfousP68XjavgK6QYWl50PS8jQYwKz0btFeDrJ6pMgDuyGq4KS/ctAXMBg9EbLvcaltqpFZiXBDxX7NtFR1j+mTRrqUhkOXV4NoHQDWppxB7VLRyLn+ZRycFL0/JsbJteNSEk5oOqZ6avkHQdftl3tIrYeGMPRttz8wZsLTW/Tz095i24u8ledb14TNJzNuhoslDT0F2/9Gw6WmvgeM4Vwbb5jHggPyPjpL8YQDXA/i0bL8bwAtkfIOZNThclbG6/VPyvQXgSwAOy7jnA3ivfH8/gB8mIgLwYwDuZuZ5MQbuBnCL7Hu2jIUc+1NbeuOO4zjOnoTIPQbANmsMiKgA4IsArgHwNmb+HBF9HcBPAvgQgJ8DcCQ3/rsBvBvAUQAvzBkKun8YwPMAvEU2HQJwEgDE07AEYCy/XTgl28YALObOq9ud80D9PwMA4PU7ZUMCTmWV2sq5qTVWr2l64jHgk2fj6pMOSavnet2K8WgfgMZC7H2As6Jr2JcTPJY1NVKLJNVMaKhegYmnglMRDOoKXVMCk6JVDtRVcymxgky5Ko7RG6CdC9ty/mquOFEsUtSx71Fb0GcCQK2aqF6W5RWrNKlagI1V8xSkua6Xvb0rlCwDKIwL/7wATjvx2dOAeBOWTpvgUz04qXl54nwPB48AVQbAzaXucRur8bydD78EgIcWHOdKYFsNA2buAHimvNA/SEQ3AngxgD8not8HcCeAVm785wA8nYhuAPBeIvoYMzcBgIiKAP4OwJ8z88NyyPlMMX4C2zdBRC8F8NLHcZtPeqjvJwEA3PqovcDjy1eMgdWVzTn9xQKoom5sbRS0ATRDPYLYlEhfiGOTITMAsLDAgX2bY+XFsr1Y5SXMrTVgdBJ83z2gfnHDT4rNR4kZEjrvhrV/Zn2BnjkX59qZDucoPFWyAfKtm2XevNECxZeuhhlSAOtAsQiGhAg0DDA/a259LR+9Yi9fHAiOMC3DzO11u2c1KDZWwRqOKOQyPTQTQ59VsQqMTIaQxdTZsE1/L8MD1ta6OmTX0mtoRchvPhJOec85lL7vKXCcJz97c4W/1WxbKCEPMy8C+GcAtzDz/cz8HGZ+FsKL/qHzjL8PwBqAG3Ob3wHgAWb+P3PbTkE8DmI4DAGYz28XDgM4A2AWwLCMzW8/35zfwcw3MfNNF3m7Vx6rKxcecyHGJi/5FHzfPZc+j2QL/kkUL93e7jIKnijNSxcwtu85d+nzcJw9AgFIKNnyP3uNbfMYENEEgDYzLxJRH4AfAfAmItrHzOco+HZfA+A2GX8MwEkJCRxF0CIcl31vRHjp/689l7kTwIsAfBbAzwL4JDMzEd0F4I+ISJRbeA6A35V9n5Kxd8ixH9qmR/Ckg8rPRXbmbeEHzY0/O28rURHsxdz+SsXEh9H9nsaKhzwlL53hQZDm+it6riSJ7vHY9ChLgQ1t4xwiRnz8FDAv/Q2Wg+iOtIlS3xCQ9OT0zy1YjQWBOww0tS5BT7JKrc8EhnIvVMjVaRjOzV/d9EvyYs5kXiurIK1HoBQLsc6Brt5BSa56YneGQ+wRgZzxUB+3VMflnJdCqyFqmqX2kugfABZCZcfYI6PUF1I4YVUf0+OLqP4X/+fhOFca2xlKmEQIBxQQPBPvY+aPENEriegVMuYDAP5avn8/gFcTURuhMs3LmXmWiA4D+D0A9wP4UtAP4q3M/C4AfwXgdiJ6EMFTcCsAMPM8Eb0BwOfl3K9n5nn5/ioAd4ix8WU5h+M4juN4KAHbaBgw89cAfOd5tr8FJh7Mb78dwO3n2X4K59cGQPQHP/cY+96NIGTs3f4wgJsvMH3nMUgOBpsuOxV+hdzpWLtljZ9L3wPUqt09EgBgZMJW3NqhcW4BOCURnQOyoh6WHgh9I5aKp6v9jUb0FEBWt1htmJdBxY9TOTf4iIQqVFiXJEAmhZi0auFQfxQdUm84oFo2LUS/pEqWS3Zf+tncAK+Ix0LHqQCzr8+0CPKoUOuPrZg5kWqHlTqoKD0blsQDUJUiT4WypTJKGicNHwKzzFc1BqWqtas+lOv8qM9AtRFSL4FPn4jeneyBcM3SD3wbHMe58vDKh85FoW2aVVDXmbwBAFCYfqC7yRIQXtbK/pDTT9WhmNnAc9LYqNUGz8yDJvdZJoG84JjnQGoQ6L7aMKAK+rrk6s9QeHG32lFYF2P9y6tAVcSMKtKr16zt84K4/IuFsL1aMZW/Gj1pai2mtbxyKw0GQ/5eq+Xgsl9dN0Mpn8WgAs0Ra6IUsxLUiCqWwZ1WEAOKQRANmrRlz2FF6jC0160gkj6rfKvs1kb3PPoHgEGtYKkhmSVk9wRNb7YUnn3pO/4QjnOl4R4DNwycLaAw/cAln4Mm9136RHp7NTwR9GV+KaxugXCwsAUFObP0wmMcx4nQHq07sNW4YeA8bjofexn4vi8CAOiGZwEAknLVxIH6IuoP3gFOHjEhnri9udOKq1m64Vo7ubjTMSvu/1wFQpaVMWoi8OsbNHe6QGMj4A1ZGS/3VPwbHQq5+4DVJ6j1BTc+LKQRqpuI10OFhvlrSHpj9DQsrYQ+D3kytpV/vAdZ9Q+N5Vb0uVoB2n46y9VuqEtIRVMd2WooxPoPI/LcZ87YfAel2mK7uekZ6f2CM2BFPC7az2FkCIk8m2x+Cwwbx3H2LG4YOI7jOI6QXJ4s/l2NGwbOBcm+8HvyJbOYuqxgkyyz+vza00BXqvVRIBVBneoPSlWg0v3XjioD4JVQ9Ciu9usSx6/1A2eDF4FPnJbz50IGqicAbPX7VClhoVqAQtFW3kpff+44ESt2OiAtXqStpBuyei6XgngQMBFiuWS6A9UkJIkVaRLRZCwi1FoDVlQLoO2oC3avel/tttUgUDFh7vlpj4ToORgaBomXRuGNFdMZyL3qGF6aAk/NdN07jY3EbpfJaPhsvfNWlF9yBxzHubJww8BxHMdxoAWOXGPghoFzQXgteABoZBDYf1A2ZjZAV7c98XCqDYf0uvy2cr8V5kkl82B9wVbEB+X8GotvrFlPA43Ft9rgtqQaqoZhdMiKB42EVMe4YgaAhqzsNU0PsDj7ohT5qVSiRyT+1yBZCbyxAV6XeecLI/VWSkwo143SejUACKt/PbYs+odKDciko6RkR1CzBRRXu+erx1XXrQz0oAg2K3UTK6rnAgCrZkF+L1rACIUiaHKie/61fpB2XJR00/T4IhzHufJww8C5IIUfeDMAIPv3P4ovO86kmt7Gqr348uECIAjlCvJiXZfqf1lq7nH9TIqbmiLF3P65RVCfvNjqYiAsLoM0HJHmWiYra/JC074IlVoUHfJCmAf116LBo9DkvlxbZDECNA0x3yshJ0yMtQpaIkhcWzejoiLPSg0UziyEkU/t1EqRulIpl4BRqXCoz2VJ76logs6qGGy1EXvBxz4KZVCfhDDUIFg+Z89FK01qGmQnteZWIqikk0to/eXPo/zy98FxrhTcY+CGgeM43wI3CpwrC9qTvQ22GjcMnMdNct1/QXbizwCENseRmILX4zEo5Gr3T52Ow6OwT1fKQwObqhbGlXpjHazVCDVd8ND+WM8/pvg1N+K2WMkw3w5aUxclbMCrjbjyp34tGJRLHdR5qHegXYreCSrIvlrV9ssqnirl6D2IoQwNKXBm3hXt+9Bp5dz58tzqNdCgtE+el14Qer8JmQhSvAncaQPikYkUitF7QKUwnsvWfyJ6FtRjQImlUEr1yeLNRWT/9rthm4ZppJpk8j1vguM4T07cMHAcx3EcuPhQccPAuSiSo78FAMjm3gtAUuBUK9D3/7P35nGSXNWd7/dELpWVtfeqUqu1gVgEWAJkBA+/D4MAWWAPAoMxgwfLRgM2ix/DjFkNlm3wDOBFDzMMIBCMzDOW9TAyMsbIAoF5g7HYBAiB0L60utXq7tqXrKzMOO+Pe25EVPVW3VXZtfT5fj75ycgbN27eSKkrzj33nN+xPXX7dyWtZp4iVw21EHRyOhcZMnTvfmTL420Mq4tQDatnac7nK/9sFV9DTGI522/fuulg5cMYf9Cazo9jOuL4TC5EZEi1kn9HXL3HwMRKhRhymKUoTudeh6zGQnUgT+mcMGGmuDpPU2iZJySu1DWF2qJ0xVSzmIzFSE8dNlv8Qfzdy7U8VdTmy/COLCBR2zZuUV65GN8BMDWVf0kW8Jiik1aPYVFVyPaNb6D0i//zkHN0HGd944aBc1zonbeHg8c+Pgvyi49ZiS70UhW6zJ199nmhbfShPJAuBgSOT2YPrSznP37Rtk3QY+qCk/vD+9RkvjXQZw+7ycKDLT5g40O7OZ9H6282zYVE0BHTTChkGWQZGP22HWFbFbp3fx58GA2Kei0LjCRuL7Ta+dyiMVIsbBRrGsxMLZxj8bjVyuog0GMlmWMWQVdBsrmYBRIf8NEoabcgKQQ9AsRCS+P7cuMsGgGJ5L9D3NqoVZHaJujvRYaCNkT2S+3dj+NsOMQ9BuCGgeM4R6IoIOU4GxzfSgi4YeAcF6VnfRAgBCOarn/cQlBbcTbTGWrztlq1VbP0bEbjCrYaUgKlXIKJA+HaqHcQPQdJOQ+K6zN39oE9sN+8DnFlX6/lbdnKu7B9ENtsW0LqtbziYqTWhcQgyLGFioYM9mcqiDpuXoXYF4JnI2LqjTHIMtNaOKVQKKpWKJKUVWY0b0AMLoTcK5CYd6PdyucUAy+llQeAbjXVx1Yj147oCvccq1pSLsHg4MIx0lbuRYgVJftLyOCOcGxj6Y/vtPl45LbjbFTcMHAcx3EcwNMVA24YOMsiBiMCpHs+Gt63hVTGkpRJTYgoiSvf5kyu0tdt/wBnZvNUw7gq32qr3YHhQvCeiQjNjOUr+lhbIZE8YDBLeSxUCYwVDmOdg+hNgHyl3pjLr7U4BdU8/kBi0J95CqS7G04ZtvGKwYQWcxG/o1YQWkoWCSilaR67MFUQXLLYgiw+oFixMf6r1YI3JooTle1eSpVMYVKnrC5C/G/Q3X+wF0FTqNj3F/4w6nTw5MQKmrEORfKEd+M4zsbEDQNnxUiGX7/gs459FvqC+1wt514ARkPgmt63K3Qsl/IH5pBlJZQLUsrxOLrLK7V87zs+6BvNgtxxQfY4m5yNH930Y5MLjQMIhkV8SMeHf9Q1aMzl2xC2NaB79iGxAFLfQD7fWN44bl+YAiLzjfyh2zOQt8W52a3TbBysgdBjrv+izHPUQmg18uBD+610djx8V9rKx4i/4+R+NBoymeZENR8jYv+dSAS1rSA3CJyNToLHGLhh4DgblbR19D5HI/E/ks7JgwcfBtwwcFac9N6CKl5WbKmg5W8PG522lfdMi2TYVtDm1o+ubtotqC5SVOzqhZql+yVx+6CRpynG90z5sPAP3VbsOj2TbT1I8Q9BXMlnWHrh0JYsCFIfjiWip9B7gjKhRCHIoa15QN/iAL1KLT8XS1O3W6E8NeQr9lI1/91iemP83G4tLOIEQeVwPhakMv2Duak8jdQCObN7T5Lce9AuqDRGQyJ6E6qV7PfQO+7AcZzOISKXAB8iuDw/qarvX3T+14G328cp4PWq+kM7dz8wCbSBlqpesJy5uGHgOI7jOMBqBR+KSAn4CPACYBfwHRG5QVV/Uuh2H/AcVR0VkRcCVwEXFs4/V1VXRGDEDQNnxUnODkZtuutDiIkTSRT5KZWz/fjk3LMBq3gYV/mPhiBEjf8464NIPO4qaP3H1MW4kpYJqEblwFhu2Pb4a70wF2svhGBFGRrIYhL0QEhblHpBgCjOJ8YczDdgxESHYmzCtk15/Ya4ih8/kKkxZumKZ54V3gd2FFb2YSzp6ss8BVmQ4OxEHlQZiWmZkKVNZvcJuQJkjGvo7c1W/lmNhGJ8QgwAFWuTBNIkv1eAnoG8QqONP/Wfnx+G/7+/guM4K8YzgLtV9V4AEbkWuBTIDANV/ddC/38DTuvUZNwwcDpGctqbSXd/BCCTRqY+iGwP8sea3BPOlUsHl0+es2j5ahOdM1niqGeQpnlUvUXNMz8PgyFyPjMWZkynYG6m0BZLFnflRZyKcr8x2yGy3cacb2QP4liWONyPlYTea/OYmYV6CEiUxz0pvPcF1cJGkjKRhgd+92D4Pcbm9tJshzmdndgDPMpCF+cTDYXhHZlcNGNRQbIJw6eE4/jwj0ZUq5kbEO1CwSQtGBWAVHvQ5iJjpDmDNmegWkfOCn+Dul9g59wwcDYgsnrKhzuAhwqfd7HQG7CYy4F/KnxW4J9FRIGPq+pVy5mMGwaOs1GJsQLLoVo/eh/H2UB0yDDYIiLfLXy+atHD+1BfqodoQ0SeSzAMfqHQ/GxV3S0i24CbROQOVf3G8U7WDQOnoySnvhEAnfxcaNA0LwfcG1bSqulC3f8isxNIfchOmTehEDyXlSduzmTBc5k3IRYWmpqEXnP5R82CNC0EJ9o/g1Yzd8XX7Zyt3qXag/bYVsKBUEpaD4whsQbD6aY4ON/I1QKzNMFwb7W5Ke6dDdc+bjDoH1S7a7TV5l0KD/KxSkpzIFy7bZPVKIiekSQvp5zdS7WS/X7SE7YcdHY8v6/4O8Qtgt4tmd6Bjtu9tJoH//alcj7uaVbkyjwkresuo/yKa3AcZ0nsP0pA4C5gZ+HzacDuxZ1E5OeATwIvVNUDsV1Vd9v7oyJyPWFr4rgNA5d4chzHcRwjkWTFX0vgO8A5InKWiFSBVwI3FDuIyOnA54FXq+qdhfYeEemLx8DFwI+X8xu4x8A5IUjfywHQ5peyAL8YgEepjFQtuC4K9MT97uZMps4nFRMTSlvojF0bV7nlapYCqNH7EPfby2XYtdD4VtVcvCgqJvb2ZsGJ2bzLhboF0TVfTIvsMa9ANd/Tz+ZuyoMSz3X1skWDp6A8H8YqjT6UVS6MMQBTTNJdDh6LPZUwxmxvuM+z6zvQkQdC/0phq2Dxah8WVnUsvo8/ghZjECB4YaKHoZg22bD/VjFeI5ahHugh/cl7wzkTqir90scPnoPjOEdFVVsi8ibgRkK64qdU9XYR+R07/zHgD4DNwP+0FOuYlrgduN7aysBnVfXLy5mPGwbOiaVcy13hMwW53cXBcFHHQErZAy0zBsb35a7+4kMvZhSMmhEQAxpb7UzJMAsgrFbyQMQol1yuQmpu95jTH2WYW/OHuJdSCHos9j8wCtg8t21deE5ThrrC1sfYfJhr77bHUGahTsPs5B6UMM8YmDg5H4yee/SnnC292XjZvG27IgZqUipDqTcYS1bSOjOUJDnIWJDerbkGwvz+whjl8LvOLSzTLEMD0G/bLOeccfBv4zjrEEFWTeBIVb8EfGlR28cKx/8J+E+HuO5e4LyVnItvJTjORqU5c/Q+RyMaW47jnDS4x8A5oUhyETp+bfgQc+mbM2jbUgfjdkH0KpSquUs8PuiqXblyXzzXauar2lg+uKgnYEGF0m0r5Va7UDAp9i9sIxSLIgEiJYjBkrGEdLkMtcJWA0CtK+gyAGLjTWiY9/T8OKfUg6bBTCv0mWtPUzLX/UQzaDjMtubYa677qabVKLBVTNqdMjUYVui9cdUf5wfo5KOhIU3zwEk7R9UCDktlJLEgy+L+Z8t+y/jblqr5FomV1s5SHhtTYBoVnrngbCS8VoIbBo7jOI4DeK2EiBsGzglHBl4JQHrA0t0qNWgv2sOPq1YppCZGDwOEvW9AH/lZ+Fyt5TEFAyYQFFMPxydzlcPJ6eyc1KJqYdyrL+d1FaxyoWoYU7r68tV1MXAvBupNWlzBxFQenGjf318ezN51XxB1OnVz8Bzsnr2PfdOPhK9Pwhxn5ucyT8G/7gmeg95K+O6+6gQPTobYjKdvCymEO2tn5QGJseLi+AGoRVXIXEUSQGL6YhEtiEZVC1UnzRuQ/VYWp6CQe2saYbz02+8kecZ/P3hsx3HWFW4YOKtGsvkyANJ9V2dtmcph0TAoLSwpjKZ5IN2AKf7NTcGAlSaOD2vrIzu254GGUeVwvLB3HrcUWm2wh3MWlBfd8O1WHthXjOSPD8doUCQJ0lNH5+dzqWN7aEttINM4ONAMLv/p1gSDXcEl31sJeg3b6+GBft/EXTz/9HDPP9ofjIE7R1vsnw1bE7XSvQDsq+/nnKEnUaS3VMgsiFsOcd6tZq4JURRBWiyIFK+TBJ3Ym99zHOP+cF+lZ/8ZjrMhEFalVsJaw38Bx1lhdP4QGQzHyH0Tdy1/IkUPy/HifyQd56TDPQbOqpNsvZz2//dfgLxugcZAw0otz/OPbWmaawWkhRS8KUu36zJFwLi1UC7lXoG4kh7oL+gcxGC7NHedxyDIeC4pg8UoZgWZRibybQjbNtDxybyWghV6ylz0k3vBvA6bTXlwc+3xpFb7IIkr9vkGpYEnAnD3+E8BOHdT8CYMVMfZ3wj3NWP9W2nKAxNhSyVuRzyh/9xcLdECKDPdiDQ9uMRyoXRzpiY5N5l7RCbMwzJo97Z3L0ytQNaD46wpVi9dcS3hhoHjOI7jEIIPxb1kbhg4a4PS//kXALS/9mYApMf283eenrvE560k88ReeNREeLZYXEFjLq9AWLaVbPQY1Gu5umHDShZXKnkQ4bR9V7m0YF99AfONvL5AVEwsl6AZV+O22h7og21hxS19i6o9tprZuDof2+ZIokfEYhJmqmX2z9wHwEA1BBNG70BPpcL9E2G1X7b9/nKSMNAVfocDjRG7v1qWfqgzBa8KIOWuUJ8CspgB6eqDbqtJEb0xjalMwEkPmLfhoT0277YrHTrOBsUNA2dNUXruhwBof+ttAMjkKFoKkfzZA7Yxmwf72cNfH86D46TPIvP7o8xyIdsgahvs3R8e4pAXIypXQ6nmUhm1LQeJbvjWXJ7nHxnsy5UUo1v9lFCeWPqHs24xcE82n5W55ouSz1mRI/uuevcgZ/c9hbm0QddUyEro6gtGzJ2jP6C3Gu7l1J7wIH/q1mfnv5+E30qTBLadg8zN5MGPsfR1pZbJNS8IOIzbCyaDTLUOVaDdJL0n3EPlN/8ax9nIJB5657+As4FIVuB/59LybeWiUXC8zKWNo3c62jzmViAGoL0CpZsdx1lXuMfAWZOUnvVBANLv/j56+90AyM+bHHiSoNPhoSdxu6DRzOshDC7SJ6j35SvjWAwIcr0B0/wnbWWGQZamGN3vpUquKhj7t1uQ2vdXD1YSjJoFedGoMWTLY2wesYxykqdBxmDI0YfoisZFf0jH1On+Ih0DAAAgAElEQVQQWPnMU87gB/seBOCxA08IfUYeAivPfGo1pEPubzxMvTwAQHf0UkztC/27evOgwqhL0JrLAi6LWyC6J/z26cgsjrPxEY8xwA0Dx3EcxwFAXMcAcMPAWeMkF/xJdqzpzeF9921Id1jd6l4LQuytI9ttD73bYgtqViugVEHHLWguehEac2EfHpBYK6FSyXX/k0X/NCTJ6wUUyxnLTH4twIE96LQFAEaPhJUqBmAgrOizFMw0zVfykWZhGyHGHdjqv9GeyYIOYwVGqQ8x0wpxCnUJgZqbazsQUyTMdBWmY62J6fw3MjVEZsfQGOsQf4Op/aQ/uNO+o4LjOCcHbhg46wZJLgIg3fNR6DWdgWnTHeiuhayELYMFCeWCez/GDmzbZE1bFuocQP6Q1EKef8xSmG8ccr9dBoLLXxumoTA+kRsEgzbeKTbXUjkfIwlGy1g6xmDdsgFiWelabzAWSmXE5rHZthQenr6fM/tDMad62bY0Zmeye75/NggjTTXDQ/5JpdNyY6j4HpUdLSBRmzPoXbZl02dGw6YBkmc+hdaXvkP1DdcddO+Os/EQxEPv/BdwNhAxdXE5xMyH1WYFgiCfVDpt2WO0vvSdZY/hOM76wj0GzrpDBoYzt3e2uo2rfshrFFhKnlS6c/d4DPBrt/IVdGLpis2ZPBjPxogaaNqezwslWflipqZgx4C12fjDp+cBjlM2x1Mt4LBnE6k98MebYQtk78yD9A8+LfSLhZDGxvItkiEb/5Tw3eduv4A9M5aSaFsJY5WUA9OhbbaYUlms6VB87xvK1RCjp6NSy0pSZ4WmRseRvhWQVXacdYTHGLjHwHEcx3GcAu4xcNYdUn9JXpExlhke3R9KL0NBCMmC7+amcvXEeC5VqNnef1RDbMwFMaQCmtVRKOdBhNvMYzC4CT1gq/zYr6ueVVDUsgUVxqDFmTFma6FfW0McQm9lgN222j9t0xnhuqSMxPTHWPfB6kCUyg9Q7Qn3WU3C++65e7IUq3M3/TwAydxMni7ZY16HbvOWzDdy1ccs7qCVp3uaiqM+MkZy5jYc52TCYww6aBiISA34BtBl3/M5Vb1CRM4DPgb0AvcDv66qEyLyDOCqeDnwh6p6vY31J8BvAEOq2lv4ji7gr4CnAweAX1PV++3cZcC7rev7VPUaaz8LuBbYBHwfeLWquorLOiPZejkA6YNXhoZqJTzgW638ARgf1uVq7laPD/dWG5gMcQkxWDCWZj5lC/RYsaBCmWFOPTUcR1djpRa2EOYbeaZCqRq2MDafgUSDwPpP1spUspLQNu2SFVCSJDNepGcz9GzOjQ7IjRhge1cwPKYtE6FWCg/0enmAZCJoLejseJhfzDSAfI6Qb6k0bMuifxsMnwkTj4KpSLZHGjDyEKXtdRznZEAQ30qgs1sJc8BFqnoecD5wiYg8E/gk8A5VfQpwPfBW6/9j4AJVPR+4BPi4iETD5R+AZxziOy4HRlX1scCVwAcARGQTcAVwoV13hYgM2TUfAK5U1XOAURvD2Qi0WsfW/1DBiqdsObYx5g+hULj5jGMa4lB/iBYYBUsgpjMuoGgULAUzKoq4UeA4Jx8d8xioqgLxL1PFXgo8nuBJALgJuBF4j6oW9Vtr1jeO9W8AcnA5zEuBP7TjzwH/Q0KnXwRuUtURu+4mgmFyLXAR8Cq75hq7/qPHf6fOapK57Ucfyg2DYqlkCGWSszoAc/nF8Ti607cMZSmLUg1BjZkqYVLOUxfjd3f1oUXvARboaOPNpOF/6e5ycHKpprRtHtUkeADm0yabxdIO49bHzGheECq696NOwuxEpskw3xPGGO55DDJlBaZiDYTozYC8XHVMz6xU8i2VqPRY6gL7LRkO8yhPzbjioXPS4cqHHQ4+FJGSiPwAeJTwoL6F4Bl4sXX5VWBnof+FInI7cBvwO6p6tCXgDuAhAOs7Dmwuthu7rG0zMFYYN7Y7juM4jkOHgw9VtQ2cLyKDwPUi8mTgNcBfisgfADcAzUL/W4AnicgTgWtE5J9U9UjVZA5yIRA8DcfafvDAIq8DXneE73bWANL/CgDSO/9bXiUxFg+K8QFdvfnxsL2XynlA4qjts3f3ZKtrjefi6kHTrJaAtubsfRZmLTXR+isgJmI0Zx6DuFXQaE9nnoJaOazmS1KmZdeWJq1C5OQobA0iRhywuWEr98HBrMrjYBq2D3TkITR6BaJnxFQfgXy7I6ZZVmpZ/QZStXnvyQM54++YpqTjBQ+L42x4xKsrcoLSFVV1DPg6cImq3qGqF6vq04G/Ae45RP+fAtPAk48y9C7M42DxCAPASLHdOA3YDewHBguxC7H9UHO+SlUvUNULlnSTjuM4zrpGCFsJK/1ab3QyK2ErMK+qYyLSDTwf+ICIbFPVRyX8Wu8mZCjEbIGHVLUlImcQYhHuP8rX3ABcBnwLeDlws6qqiNwI/LdCwOHFwDvt3Nes77V27RdW8LadVSJ53LtID1wTPsSguxgTUK7mokOxbgDkkfk9thc/N5OtoOm2wMRYTyGKIAE0JvI+0bNQKaRK2mp8KK7ALf1voqDBNDUfBIvq5QHatrNViqv9rq5sla/TJtJk4kNUarkI09jD4dzAMBqllqMIU7zvOKci4wfyDIxIqwUjscaDzWPTAOyaxHGck4tObiUME7YDSgTPxHWq+kURebOIvNH6fB74tB3/AvAOEZkHUuANqrofQEQ+SAgYrIvILuCTqvqHwNXAZ0TkboKn4JUAqjoiIu8Fop7rH8dARODtwLUi8j7gVhvD2QAkmy9b8FkbXwzvxSJFMe2v1YQpc7/32QN8YjpXUIwP6Tl7QHf350GKtUKZ5iTfagiTKGcBi2LBjzOmXZC0ZumphGsrVuyItJU94LNgwXIt29KQIXPlR32FWpatm81HG5NIVyg1rb1mIBTSH+nuz+8ZgmFR71kwbxnckW2RRMNK9j9K5bmD6D3FcB3H2cCIpytCZ7MSfgQ89RDtHwI+dIj2zwCfOcxYbwPedoj2BiGA8VDXfAr41CHa7+XQqY+O4yzCjQLHOfk4rGEgIhNHuVaAPar6uJWdkuOsDFL75ew43W+OqbgaaBayY2NbIrnY0fiiUsgzk7mC4F4r4VwuQb+txpuF1Me4Gu/bDkAlCSv3TV3DJJMWTGgCSg2adMWCSZauSKmQGrlpu7WZ+FFSQVObo+aqhVkEbaFk8kHVIKPHY6YBWxdpOCRlpBZVHkNqpNbG0fk2jnMyIZSO3mmDcySPwT2qetCKv4iI3LrC83Ecx3GcVcGVDwNHMgxetoTrl9LHcVadZMtvLfisY59F4+o6rrwrtTy1L3oAZixNsNXOBZSahQDGWGchLdRgsNX9fDW8j86FNMRt7Z4s3kFMSKmcVJHEVuhxzPnGQtllgEmTOk7TPKgwxhu0mnkg5QFTL+wvpCtmqZfWp693oXcC0Mm9ubchqzUxR3vPMaonOo6z7jmsYWB78QBYlsA5qvoVyzAoq+pksY/jrCdk8FXZsU5cFw7KXWjxYQtQtpjVxhxMmRHQb1sF9Z7swZox38i2KSoaHu6zVtOA3p2IBTXOmHxHu92iL14bAxlT8odz1BuIKo71wkM9nqvWQ6YB5EaLprmyY5+pMvYOh1Ozo/DIrnBu0LYUqtV86yHee6pUnvMkml+5Dcc5WfAiSkvQMRCR1xLkhj9uTacBf9/JSTmOszZwo8BxTj6WkpXwRkIU/y0AqnqXiHgtVmfDENUTD0X66CfCwcwjITixyMx07kWoxnTCriz4UE3JcOfA4wFoaYs50yNotoNXYSitofvuD9fG8QdOKaRLmnfANBGkNpBvOdxvDrtNA7mnoG5bDz2bMr0FqVnQZPQIzE4cnP5YqeVFlOKWwvZhyqfdf9jfxnE2Ih5jsDTlw7liWWJTDTykjLDjOI7jOOubpXgM/kVE3gV0i8gLgDcQyiA7zoYn2fba7Dh98MpwEOMKZqfzoMMYHzCwORMbyrBqiKXGFHVboffE6o0Te/IaBoX0w7yWQfAcSG/3wu+G3DvQvxk2L6z8SJoivVsXjKvTFoewdz+ceorN28Zrt7IUyqziYm0A2R7FQx1n4yPIupQwXmmWYhi8A7icUPHwt4EvAZ/s5KQcZy2SnP6WJfXLNBMWM34gkyzWzVbUs1JDuq0YUlQebDcXKCkC6P4Hw+fB7XlJ6K3h4S5dfXn2QpRLntwb3HqNqXy74GErC5KmMDGxoD/1QZi2QMv4h1FKJE+9EL3/Dhp/9lIAar93/ZJ+A8dZr3gRpaMYBiZnfI2q/kfgEydmSo7jrAiN5aca6v13rMBEHMdZTxzRMFDVtohsFZFqMc7AcZzDEzUT2t8KKt6y1Vz0289AejaHYysNrSMP5HoKcdU/PQb9Ib43q4HQms0/xzoK3ebmLxZJitsA9SGw79LRIGusk2Yo1LrCdgIgZ50W2ib3w6PmMei1+QwAW8IYsjjw0nE2JL6VAEvbSrgf+KaI3EAohQyAqv5FpyblOI7jOM7qsBTDYLe9Esi0WDwrwXGOQulZHwQg/cl7Q8P0CPQHkSEqtspvt2DfI+E4phCmKbLV/qlZimHmaZidyAMGiyubLC7A3rt60cZ4GGLneWE+MaVxbBKiFyN6KxpTeTCjlWTWsYez7yptD3ENjQ+8BIDa213KxNl4iHi6IizNMPiJqv6/xQYROWRFQ8dxDiY59z0ApAeuyTMEuuyBnCRBRhlgs8mDtJpZ6eaIxOyHaj3fOoh/wFrN/DjqH0gS9AtKZcrTY+E7e8zYaMxlD/+szPRMA5oWuDhnQZB3PWDnZknOsS2HPR5z4GxsXPlwaToG71xim+M4a4nFcs3HQ6wV4TjOScORyi6/EHgRsENE/rJwqh9odXpijrPRSDZflh03Wl8CoGtwB9q8PzTG1MFWE+kJ2gapBSFGj0A7bVFm0baBTuSqhsVthjiepSvG8EFtt9CHg7ZCVmq5XMrUG6Uc+uv+XbT3hrCi8mNOD+/D4dzch15G15v/7jh+BcdZy3h1RTjyVsJu4LvAi4HvFdongaUldDuO4ziOs644UnXFHwI/FJHPWr/TVfVnJ2xmjrOBaaut5is1qHUvPNmzKfMGJDHM1+IKZttTqB1328q+UiwXHZlv5FsJdm6+J5RiLk8fQPqsQmS3fXcs5QyZ10ESoTQ4Zm1hPtIb+rV+8OiR7++rvwtA6XkfPmI/x1lreIzB0oIPLwH+DKgCZ4nI+cAfq+qLOzozx9nAlCRmIDRzZULTJ2B6JKT9SALN4MqXgZDNkJAw1QrZBs007P/3VoaoxjGMRAtZD3aunMRtgypUK+E4ahv01vMMhWhQbD0F2WoFnSbDd0bdg1pvnfS3fsG+zDYp+gay79d77wtf/3e/GRpqXZR+6eM4zlpGVnErQUQuAT4ElIBPqur7F50XO/8iYAb4TVX9/lKuPVaW8gv8IaG64hiAqv4AOHM5X+o4zlFYiT9O7RUIBUpXYIxa1/LHcJwNjKkMfwR4IXAu8B9E5NxF3V4InGOv1wEfPYZrj4mleAxaqjoejBXHcVaCWvlF2XE6+plwELcDytX8eDIoFKoVVeoZGKbef0Y41QxKhSUpMzUfXP7RK1Cr9ZLEFEfzHsh40EvQvbugYcGKsVz0yDj0ms7B4NZ8HpbCGD0McsrZ4f2saqbGSMvGmh7JtyFOt1oQT3xK+M6f3b7EX8ZxVpdVUj58BnC3qt4b5iDXApcCPyn0uRT4K1VV4N9EZFBEhgkL9aNde0ws5Rf4sYi8CiiJyDki8mHgX4/3Cx3HOblwo8Bx2CIi3y28Xrfo/A7gocLnXda2lD5LufaYWIrH4HeB3wfmgL8BbgTeu5wvdRwnJxl6NQA6Y2qCSRkdfzgcR8/BVBA80mRvVsa5rzsEE8pQP/PmKWi2TbVQU6qloGRYntwXxjhgY5ZLsClcS6sd+u/dj9gxXeb6792SByXGNMhYmrk5k8dE7A1VG3V0Atmx3fqbh/H+u5GuLujvOcZfxXFWB+mMru9+Vb3gSF97iLbFMzlcn6Vce0wc1TBQ1RmCYfD7y/kix3GOjNSD3HC656OhoVKDsskUxwfyw/eioyEQMJNQPqNBtz3A60M7AZjUGRrtGabmRxm2rQe1mAMZ2pk91HVvSDSSSiWfyLxtKSQJVOuhzLNtS8SCTJlRADBgBkqS5BkWMZAxFmZyHOdI7AJ2Fj6fRpAMWEqf6hKuPSaOahiIyAXAuwj7GFl/Vf255Xyx4zhHIFZaXAZT86PLHkOqK7DS3zRw9D6Os1YoVis9cXwHOEdEzgIeBl4JvGpRnxuAN1kMwYXAuKruEZF9S7j2mFjKVsJfA28FbgNW5RdznJOJZPj1pD+6InzYZJ6C6DHo6y3UTbBVfqsZiiABOhVW6L1Dp1LtCymOk20LXNwUFhXjzREGqzZel6U59s5kXoFMBnkz+cp/2lb+FgTJvpF8e2CrLVbqg3kWQ9x6ePyTw/s9XmPBWQ/oqhgGqtoSkTcRtupLwKdU9XYR+R07/zHgS4RUxbsJ6Yq/daRrlzOfpRgG+1T1huV8ieM4JzFuFDjOUVHVLxEe/sW2jxWOFXjjUq9dDksxDK4QkU8CXyUEIMaJfH6lJuE4zkKSn/ujBZ/TfVeHg+7+XBAprspnxrIgwqxaYnOGrungUeiyIMW5NKQV1sp1Wub8K2+2+AOAUUuNPBC2IKT6AFpMRQSYMEGk/p5MDTELkJxv5KmLxWqPWwZJv/3jY/0JHOfEo6zWVsKaYimGwW8BTwAq5FsJCrhh4DgniGTr5Qe1pQ/8OQCy9TFZm1rGAvMNdL4RRI4m9wJQ7R4M/fu3My/2TznqDmw7B+pDoW1gXzYG0yPB6EgX/bFstaFmRki7sH1QXfgnRe+8E4DyK645tht2HGfVWIphcJ6qPqXjM3EcZ2VZCeXD6IlYBqXnXLn8eTjOCWF1YgzWGksxDP5NRM5V1eNWUXIcZ+VJzvivALT/6XeQn78QABk0XZP5BjplK/9du8J79QAAuqNFpS/qDZjLv1xjvtc8Cr0hMLE830RnLbMhaiBEQyFVqFvmRCz5XKrm2RQxCLFcov3N36P07D9bgTt2nBPAYu/YSchSDINfAC4TkfsIMQZCiIPwdEXHcY6KGwWOs75YanVFx3HWKKUXfgwIwctRHEl6tyIWM6BbLGAwKSigNyztMAYJVppEiaNWV0hRTKs1kpLVTUjCWa1aDEPagqYJIc1Y8GG1AtWF5Z+lr4f0R1eg9zxE6aWfWt6NOs6JwLcSlqR8+MCJmIjjOMsnGX79gs/N9pepmFaBToetBKZH0Ep4gEvP5tDWbqFzQXa5HFUN47ZAqcpMPRgLpZ7HA9ClCfroXeG8lWRmbBI98GA4jkWX+iyDolal9ddB+rn8659Z/o06jtMxDltESUS+f7SLl9LHcZzVodn+8vIHKVWXPYTuO7D8eTjOiUAt+HClX+uMI3kMnigiPzrCeQFc69Rx1ijVUtgF1NmgTxYDE7XdzGswWLqizhzIVA21bxvWEZHgWahHBcRauK6lLcpWl0HjH77u7lyVcfsWa+tHTj8TvfVW9xQ464N1+CBfaY5kGDxhCdcvP5fJcZwNjd5662pPwXGcY+CwhoHHFjjOxkC6XwwUPAf9w1k6oc5YOuK+RyDGA8T0wzRBJ4MaYqa2mIY/C6WuXjTWTUjzqo1ZrdfoYZAEedrTmf/siqm1Ok4HUU9XZGlZCY7jbACigRDR2RvyrIRNW/ITrWYIPGzOQFcdDuyHKQtIjIWbombB9Dh0WzGlchXZcha6966wLTEygcYSzm1l7i9+ha7/4oKpjrPWccPAcU5CovfgkBRLPh/Yf/h+0+MHj7vXMhVGJrK21rfuBnCjwFkfeIzB4bMSIiLyJhEZOhGTcRznxCDdLw4ehLQVXqUylKvhlZTDq92CwUEY6IdyObya8+E1ORq8CFMzoabCfAOd2BuUEYsyymlK+cKzkZqvQRxnvbCUf62nAN+x1MRPATda+UfHcTY6K7B6av/wwRWYiOOcALy6IgCylGe8iAhwMaHS4gXAdcDVqnpPZ6e3NhARN4Sck4Z078fDQbWOlLpC2zdvDm29IahQNg/lQVqxZkJzPngVABIJ77aloOMT0AhBjaVf+nhnb8A5Gfieql6w0oNe8NSz9btf/5OVHhYZfFVH5tspjrqVAKEwAvCIvVrAEPA5EflgB+fmOM4GQMcnjt7JcZw1w1G3EkTk/wIuA/YDnwTeqqrzIpIAdwFv6+wUHcc5kSTbf3tJ/dKfvDcclOzPyNBgiDcA6AkVGqn1IqeeCjOTeWaD46xhVF2eZykxBluAX1msa6CqqYj8cmem5TjOWic59z0ApN9/d2ioz8IWK/u8OBd8Ygp9aM8JnJ3jOMfLUooo/cERzv10ZafjOM6G4xE3CJx1grrAESwxxuB4EJGaiHxbRH4oIreLyB9Z+3ki8i0RuU1E/kFE+q39GSLyA3v9UEReWhjr6db/bhH5SwuGRES6RORvrf0WETmzcM1lInKXvS4rtJ9lfe+ya5dfJcZxTmKSp70vvJ7w7qCaGJUTIWwz7NgJSULp0qspXXr16k3UcZaCF1HqnGEAzAEXqep5wPnAJSLyTEKcwjtU9SnA9cBbrf+PgQtU9XzgEuDjIhI9Gh8FXgecY69LrP1yYFRVHwtcCXwAQEQ2AVcAFwLPAK4oaDF8ALhSVc8BRm0Mx3E6xZ6HV3sGjuMcAx0zDDQwZR8r9lLg8cA3rP0m4GXWf0ZVW9Zes76IyDDQr6rfsuyIvwJeYv0uBa6x488BzzNvwi8CN6nqiKqO2vdcYucusr7YtXEsx3GWSbL9t0Pw4p77w6tcg52PgXqN9tfeTPtrb17dCTrOEfGyy9BZjwEiUhKRHwCPEh7UtxA8A1G0/VeBnYX+F4rI7cBtwO+YobAD2FUYdpe1Ye8PAVjfcWBzsX3RNZuBsYIBUhzLcZwVonnD92ne8H2YmwqvTcPIzvByHGdt01HDQFXbtjVwGvAMEXky8BrgjSLyPaAPaBb636KqTwJ+HniniNQAOdTQ9n64c8fafhAi8joR+a6IfPfQd+c4zpKIlRYdZz3gHoMTU0RJVcdE5OvAJar6ZwQVRUTkccAvHaL/T0VkGngyYVV/WuH0acBuO95F8DjssniEAWDE2v/domu+TtBiGBSRsnkNimMtnsNVwFU2T1c+dJxjoPauLwDQHAzKiZVXvQQ1NcT2v7wFgNJzrlydyTnOYdF1+SBfaTqZlbBVRAbtuBt4PnCHiGyztgR4N/Ax+3xWDDYUkTMIsQj3q+oeYFJEnmkxAr8BfMG+5gaC+BLAy4GbLQ7hRuBiERmyoMOLyWs8fM36YtfGsRzH6QCVV3kYj+OsJzrpMRgGrhGREsEAuU5VvygibxaRN1qfzwOftuNfAN4hIvNACrxBVWPN19cD/wvoBv7JXgBXA58RkbsJnoJXAqjqiIi8F/iO9ftjVR2x47cD14rI+4BbbQzHcTqA1Cu0/v4fKV16CdR6Q9vwVgDa3/w9eCT8Ey+97H+t1hQdJ0dxHQOWWETpZMe3EhxneaQPXgnd/eFDYusRTUm2/NbqTcpZz3SmiNJ5Z+h3bnznSg9LMvz6dVVEyYukO47TUdIHPZbAWUd4jEFnsxIcx3GS09+CDAwjXX3hVe5Cyl0wtne1p+Y4ziFwj4HjOB1Fx69d7Sk4zhLxrARww8BxnA6S6s1BQKQxBc1Qdlmn9oX32+5cxZk5zmFww8ANA8dxOsdkMyQD9Ws5MwiYCwZCe+/0ak3LcZwj4IaB4zgdpb/tf2acdYKXXQbcMHAcpwOMz4U6ZfVyP60ylPbeBeNjAOhDewBo7Zk67PWO46webhg4jtNRSnvvWu0pOM7S8RgDNwwcx1l5+qqbAJDJ/dC7FX3kbphphJP9QQGxtKVO+1tvC8fP+uCqzNNxDsINAzcMHMdZeaTdWtjQ04fuG1nQVD57E0z4doLjrDXcMHAcp6PopAsZOesEDz4E3DBwHKcDSPliAHTyc0j/MDo3iQz0hZNTIV2RzYPM33L3Ks3QcZzD4YaB4zgdRecmV3sKjrN0Uq+Z54aB4zgdQ/peDoCOfRY95fTQuOu+0DY5RbKpe7Wm5jiHxrcS3DBwHKfzyOCrSEc/E47POjc0zoxS2r4FgPYXLgegdOnVqzI/x3Fy3DBwHMdxHPDgQ8PLLjuOc0JIhl5NMvRqJmplJmplZPMZMLgVBrciF5yPXHA+6bffudrTdJw1hYhsEpGbROQuex86RJ+dIvI1EfmpiNwuIm8unPtDEXlYRH5grxcd7TvdMHAcx3GcSKor/1oe7wC+qqrnAF+1z4tpAf9VVZ8IPBN4o4icWzh/paqeb68vHe0LfSvBcZwTykCXBSROfg7p2x4a54Mqop5VJ33gz8Px3fcDUHreh0/4HB1nDXEp8O/s+Brg68Dbix1UdQ+wx44nReSnwA7gJ8fzhW4YOI6zepTCnyCdmQ2fJ/fDo0Eh0Q0C54SjrMUYg+324EdV94jItiN1FpEzgacCtxSa3yQivwF8l+BZGD3SGG4YOI7jOA4AHQs+3CIi3y18vkpVr4ofROQrwCmHuO73j+VLRKQX+DvgP6vqhDV/FHgvwex5L/DnwGuONI4bBo7jrA7tJrSrC9saTXS2sTrzcZzOsV9VLzjcSVV9/uHOicheERk2b8Ew8Ohh+lUIRsFfq+rnC2PvLfT5BPDFo03Wgw8dx3EcJ7L2gg9vAC6z48uALyzuICICXA38VFX/YtG54cLHlwI/PtoXumHgOM6qIIOvQmu9aK03a9PRcdo/e4T2zx4hffBK0gevXMUZOs6a4P3AC0TkLuAF9hkROVVEYobBs4FXAxcdIi3xgyJym4j8CHgu8JajfaFvJTiOs2pIw8oul7vC++OeSPlxT4T77ka/d9vqTcw5OVmDwYeqegB43iHadwMvsuyFfsYAACAASURBVOP/Dchhrn/1sX6nGwaO46wt7vOKi85qsSKu/3WPGwaO46wezVCCWZvTAEi1Bz0lZGPNf+W4UrAdx1kmbhg4juM4DqzJrYTVwA0Dx3FWDW3NhYO5EGug5Sp09wOQbKqt1rQc56TGDQPHcRzHibjHwA0Dx3FWh1RvhgMPhA9J+FMkUkLNe1Da3gNA+x9/O3z+pY+f+Ek6JxmKqgcfuo6B4zirgqRpqJVQKkO1DtV6vrUAyFOfiDz1idBbh9467X85avq14zgrgHsMHMdxHAc8+NBww8BxnBPKbMuk2iVBejZbo9V70RStheBDqYatBMpWT2FqkvTu94fjscnwngjJ0953AmbtOCcPbhg4juM4TsQ9Bm4YOI5zYimJ/dlpNbKgQ+qD4b3dQtpNAHR2PLSZB4FKDVrhHPtDOXndu/9ETNlxTircMHAc54TQbH8ZAIkxz2kL5q1Wgq3StDULk/awj0ZAyf5MVWr5tkLdNA7KZZqfeCUA1dde29H5OycDLokMbhg4juM4TsCDDwE3DBzHOQFoejNqtd/aaSs/Md8I72JehMn9wZMAMBXqKFDrWtin0CY7T0HvHQnjXv8aAEov/dSKz99xTibcMHAcp6NoevNqT8Fxlo57DNwwcBync2jrnyFtoaVy5ikoxz+8jYk8wHD0EEGEDYsxmDGvwnBX7jXoGwrvtQbl83eG44lQoXH2j36Z7iu+eNS5pQ9/OBxUaiTbXntM9+U4Gxk3DBzHWXEWewlUU5L4UG818hMHHg3v0VgYHMyKKJHuCu/N+fBerefBh3ELolJDTt8Rji1IsWv7FtKXPj0fD0hOD6qJ6f5Po9/7DgDtm28JfdoebOYY6sGH4IaB4zgdJsVds846wrcS3DBwHGflicZAW8P2QbPdoGfe/uDG1MRdd+XegLhKK5Xz7YL+6DmwYMS5KYilFKLnoFrP0xm7esP7zlpoB5gZC0PEbYP5BnL+eQAkd9wRmv7tvmXereNsLNwwcBynozTbjaN3cpy1gnsM3DBwHGdl0PRm5jUEDEZPQTmpUk6qiIJOPxw6RuGi3nq+so9egvkGUrb0xIHhMO7MaP4l0Xugaf4er431FkplpDYQjvttjNZs+NyYgnIQR5Lu8F57+98v57YdZ8PhhoHjOMtCZ28AYC5t0ErDQ78ntT8tiT3AW818JRYf7l29BwcTdtXRdthekEq3jWEP/nItvzYaF60mzM0snFCpnBsOdq0klTDXJIHJEPCoo+PHe8vORsWDDwFIjt7l+BCRmoh8W0R+KCK3i8gfWft5IvItEblNRP5BRPqt/QUi8j1r/56IXFQY69dE5Ec2zgcL7V0i8rcicreI3CIiZxbOXSYid9nrskL7Wdb3Lru22qnfwHEc8oe446wH0nTlX+uMTnoM5oCLVHVKRCrA/xaRfwI+DPyeqv6LiLwGeCvwHmA/8O9VdbeIPBm4EdghIpuBPwWerqr7ROQaEXmeqn4VuBwYVdXHisgrgQ8AvyYim4ArgAsIIpffE5EbVHXU+lypqteKyMdsjI928HdwnI2NBf11AZXE7OxY78A8AjozCk1b2UfvQExLLPRLtr2W9IE/D9fE81ZoSSrd6LxtCcS/XAcO5HoH5VJ479+WbS9oM2gbZNsMM5PobXcCrpDoOIejYx4DDViFFCr2UuDxwDes/SbgZdb/VlXdbe23AzUR6QLOBu5U1X127ivxGuBS4Bo7/hzwPBER4BeBm1R1xIyBm4BL7NxF1he79iUreNuO4yxiQYyA46xlYq0E9xh0DhEpAd8DHgt8RFVvEZEfAy8GvgD8KrDzEJe+DLhVVedE5G7gCbZNsIvwII/u/x3AQwCq2hKRcWBzsd3YZW2bgTFVbS1qdxznOImpiSIJybyVTI4r9fE94b05l/+BrFbswhTK9ifIYgfSez8AbfvnGd9jHEKpDG1byzRjAGMf1G3c6GEoldHpA+G4Eas32r5xucTcD/Yu634dZ6PTUcNAVdvA+SIyCFxvWwSvAf5SRP4AuAFYsAEpIk8iuPsvtjFGReT1wN8CKfCvBC8CgBzqa4+j/SBE5HXA6454g45zEjM9H4IOxdz2zXaDrvairIGmCQ+0WnkQYcVKJreb0FrktGy1oWZBh2YQZBkGQFhrAN2hTWfH8wDHyOwETFlgYdRJsO/Wn91HOj6H4xwaDz6EDm4lFFHVMeDrwCWqeoeqXqyqTwf+Brgn9hOR04Drgd9Q1XsK1/+Dql6oqs8CfgbcZad2YR4HESkDA8BIsd04DdhNiGMYtL7F9kPN+SpVvUBVL1jWzTvOyU6rdfQ+jrNW8K2EjmYlbDVPASLSDTwfuENEtllbArwb+Jh9HgT+EXinqn5z0VjxmiHgDcAn7dQNQMw4eDlws6oqIXDxYhEZsmsuBm60c1+zvti1X1jpe3eck4GSlClJKI7UTlskkqCNcbQxDiN7wysaBd3d0NMXXqMj4dVshIyFmMqYpiSPe1dY3SdJCCCUJP+cplCqQqmKzk2ic5MwfiAENTZnQlDjfCNsOSTJgpeOjqOj46Qj00giSHIo56HjONDZrYRh4BqLM0iA61T1iyLyZhF5o/X5PPBpO34TIRbhPSLyHmu7WFUfBT4kIudZ2x+r6p12fDXwGYtDGAFeCaCqIyLyXuA7hWtG7PjtwLUi8j7gVhvDcZxO0d292jNwnKWhoF5UCwmLaOdIiIj/SI6ziHb6lQWfU00pm9iQ7r7DGs2NWuvOxYlGbP8/SaC/Jxz3hCqITI5Cj8UUxBoIUdkwKSOlyoLv1OkDecxCyYIUNc1TIuP77kfCqdFxmt8OVRuXUprZWbN8rxPbvBc8Zove8v5fXulhKb/imo7Mt1O48qHjOMeMtv4ZtQd2ZjYLuZhRdNXH7dWZaZiaXThIrZI//DNVxDQPUowP+limudVEa1YoKQY51gczVcMseyFNoRoMDp2yLOdek15utymfkQczOs5BePDhiQk+dBznJGYdBl85zsmMewwcxzlmpHwxOnEdAI16WI3XWuT6AVVz70fFkWYDqpY62G+r/mo99zBEVcRqBekesi+JngOrc9CcztIV1bIWmW9AtZSPB0Ep0dIlxbYvNI6/Zx/ppEs0O4dBFTzGwA0Dx3E6TNPLLjvrAwXUtxLcMHAc5zixoL+SyYLogbtgfCyc6ymUUy5XQyxBjCeIsQCtZkH0KPSXrr5s+FgqORM1KlUJmml5mzam0KhuaHUUsqqMgLZMzMjqOVCv+daG4xwFNwwcxzkupPvFAIzPhdIjfUk5f+jOWqBhJn/cyiWLC0WUoqqh9AVpkXT/p5HqooDEcmGM+CerZMZCuQr7QxllxoJRorWuoKAIuY5COR9TG+3jv2lnY6P4VgIefOg4TqdJ/M+M46wn3GPgOM6yGOgKq32d/nxeeCQG+83NAaH+QbL9twFIRz8DgFR7sgDDdL/pnEkSFA0hL9kcCzLNF2IV+raH90otNzzqUc+gDE3bXqh1hXfzXEirj8pjB5d1v84GRoG2bzW5YeA4TmepufKhs15QDz7EDQPHcZaJjl8LwGQF+racFdr2WQ20uTlozELvQOYVyIIJ5xuhOiKACRdJqQsdezi0xWDFmIYIeQpjOVc51HHzMOzdH7qcsSP3HsS0ychMA3n8Wcu4W8fZ+Lhh4DjOspjrCUGFVUBNrVCGQnFTjTLIzZl8a2BqIr84qhsa2p6Dnk35NRQyFepDue7BnG0VSAJjZhhEtcWxSdgStgv0ITMyrPxyet+jlC543HHfq7PB8eBDwIMPHcfpNC0XFHKc9YR7DBzHWRZd88ErkHbVaaXBCKhkngILGGw0oWoGQtwaaExBYoFesfaBJEjdlA/rixQQC+jMaDiYbyA7Twlt05YiWS6h94VCSbovpDBKd/BMJH0V1LYcHOeQeIyBGwaO43SYhnsMnHWCl10G3DBwHGeZ6OReAGS6DEPDodG8ArLJYg2m9pGc+kYA0t0fsQvT3HtQjEWInoLF52Yn0KhuGKsnagpbtoW2NMxDZxt5emKXqTJOBwXE9r5Z9L7xFblvxzkRiMgm4G+BM4H7gVeo6ugh+t0PTAJtoBXLPC/1+iJuGDiOsyySba9d8Dm9/0+ZPPUxAPT1Bzc/2iZ99BPhOOoRVGr5cXz4V2roxB6kb3t+zt51bhJmTN3QVBSjcqLOz8KWMIaMjIS2fSPIDvv+8RDwWO6uMH/HgRW4a2djomtRMvsdwFdV9f0i8g77/PbD9H2uqi7eKzuW6wEPPnQcZwVJ7//Tg9p0/OFjGkOieNESiV6EBW37Ro5pDMdZw1wKXGPH1wAv6fT17jFwHGfFSM5864LP2v4K0j+MlJ6fewwsmDA59Y2kD384tBW0CnRqXziIAYlFD4OVU2bKvALzjVzTII6xcxOy0wYzD4PULFWyPk15Low7/5n/GIZ99f9z3PfrbDDWZrridlXdA6Cqe0Rk22H6KfDPIqLAx1X1qmO8PsMNA8dxOoqUnr/aU3Cc1WaLiHy38PmqwoMbEfkKcMohrvv9Y/iOZ6vqbnvw3yQid6jqN45nsm4YOI7TMVKBdvoVkumx3BNgq/5039V5x+gJ0DQXPVocfzBdCBo0wSKSJCv/HOMNqNYzASSN48Z94+Y8OheqK7Z3W5/Jz2XVHR2nQ5LI+2Mw4CG/U/Ww1rOI7BWRYVvtDwOPHmaM3fb+qIhcDzwD+AawpOuLeIyB4zgdJZkeW+0pOM7SiFsJK/1aHjcAl9nxZcAXFncQkR4R6YvHwMXAj5d6/WLcY+A4TscoJWEhtH/2s2zutgyCKE6kaZbRkO75qF1QhrbpHoxaAGGvxQ6US9AKq/3MYzA1AztDnYXMs9CYQKct82BiYsEY0mqTDJqcsv3BTv/1Ztrf/L3QNhO8FKUX/I/l3LbjrCTvB64TkcuBB4FfBRCRU4FPquqLgO3A9SIC4bn+WVX98pGuPxJuGDiO03G2dL+KVG8OHwqqhVlAYizTDPmWwZS1la3oUm8fiD38tw9nY8RtiKwgU5LArJVqjlsIsTRzuZQZCaWnn59/txkayePetaz7dNY7K7LCX1FU9QDwvEO07wZeZMf3Aucdy/VHwrcSHMdxHMfJcI+B4zgnhEQuAkDnzcM5PYI2pxd1SvIqif22RVDrCu/tFoyaV2DQPAFdvbk3IKY3NmagZceDgzZGEESibxvJ6UEVMaZNanMGPeBxEA5BEtlrJbhh4DiO4zgZ7TWnfHjCccPAcZwTilQuAUAbX4S5ydCY2J+ixlQeYGj1DmI6IvN5DQQmLIBwUxXSRR6DuTkY2By+q3/7wjFazayfxu8ujNf+l7cAUHrOlcu8S8dZv7hh4DjOqpBWayS9WwHQvXeFxv1jaDsYBjLQF9rKpmdQrkItKh+aETAyAqecFo7r9vDvSbMiSxGdsEJP5a5sC0Eq3eFcV2+2baH37lmx+3PWH+pbCYAHHzqO4ziOU8A9Bo7jrAql5PnoxHXhg1VLpDaDNEzHYHGVu2odGlYwKW4p9A/lyodl8wBM7kUPLCrcZKmPum0rYl6KjEoN6QnXtmdC2mLjAy+h9va/X8bdOeuTtZeuuBq4YeA4juM4EJQPfSvBDQPHcVYPffReAOTMp4WG+lCujDhqZeVjoKEkUAsre6YscHBqPAQUAloq5/0mLA3SqiqyzbwEExNoDFLs3RK6l7vQU88EoPyckBrpZZudkxk3DBzHWTWSx74DAB2/FoBW7yZKDdMqiFoEZfszNT6Rr+biVkJrHrpM5yCWXW41odcMiJjhELclhrbk0smtENSozZkgxQyZ4SFDA6Tff3eY49PetwJ36qwX1LcSPPjQcRzHcZwc9xg4jrPq6GRIJ2zW63RHRcJpCzSMq/24+gekz9IRe+tZ+mHcUmB6PN8KsGuk34IbNc1LPM9ZLYYkyb0I8b1WzdIf02+/M3R7xn8PQ153GcmFPxfazvivx3/TztrDYwwA9xg4juM4jlPAPQaO46w6yWlvBqCdfiWrtCiVEEeg4xNZP+mxOIJNA3ZhOQgfAUxa0GKaIk94UjieN3GkLqu7UKziWKyxEL0O8T0h91BsD0GK6YFr8msnHz32m3TWAeqSyLhh4DjOGqKUPJ90z0fDB8sokFp4MFOvQd+WhRfMTuRbA/FBXq9lbdITpJGjYaBzUwcbAY1ZGDTp5DnLgNi3D502A+UJTwnv9aHsa9XGT+8IgYnJE959fDfsrC1c+RDwrQTHcRzHcQq4x8BxnDVFMvz6BZ+jOqK253IPQDw3PZIHDJZLNkA5eBIAHQlBjVnp5jSFam3hF6Zp7j3INA7qyKDVamibToIFSGbfURzX2Th4uqJ7DBzHcRzHyXGPgeM4axrpf0V2HAMApS8oGcr2xyPdLw7nHiyUSp4PNQ9o2nu5IGAUV/sxELExB1Omshg9B9UuqFnA4uL0xrSVj7tpeHk356wtPMYAcMPAcZx1RLL5ssOfO/0txzRWuvsj4aCf3JAoqi1acaYseyG+V3ohtUwJ9Qj2jYYrH/pWguM4juM4Bdxj4DjOSUly6hsBSB/+MDStKFN0I09MhS0GgL5FWwqtZrbNkGy9/ERN1zkBqKpvJeAeA8dxHMdxCrjHwHGck5pkx+/mqoYNix1IR9Bx8yKMhmqPEqs41mvQGAOgff1rACi99FMnbL5OZ0k9xqBzHgMRqYnIt0XkhyJyu4j8kbWfJyLfEpHbROQfRKTf2l8gIt+z9u+JyEWFsf6Dtf9IRL4sIlusvUtE/lZE7haRW0TkzMI1l4nIXfa6rNB+lvW9y66tduo3cBxnfZBsviwENtb6w2vrKcjWTcjWTWF7IVV030h47dmHPvwI+vAjpONzpONzqz19Z6WwrISVfq03OrmVMAdcpKrnAecDl4jIM4FPAu9Q1acA1wNvtf77gX9v7ZcBnwEQkTLwIeC5qvpzwI+AN9k1lwOjqvpY4ErgA3bNJuAK4ELgGcAVIhL1TD8AXKmq5wCjNobjOI7jOHTQMNCACY9TsZcCjwe+Ye03AS+z/req6m5rvx2oiUgXIPbqEREhJBfFfpcCsbLJ54DnWZ9fBG5S1RFVHbXvucTOXWR9sWtfsrJ37jjOekW6B8KrvjloFGwaRnrqoXhTYw4ac8x/5yHm7xph/q4RShc8jtIFj1vtaTsrhAKapiv+Wm90NPhQREoi8gPgUcKD+hbgx8CLrcuvAjsPcenLgFtVdU5V54HXA7cRDIJzgaut3w7gIQBVbQHjwOZiu7HL2jYDY9a32O44juM4Dh0OPlTVNnC+iAwC14vIk4HXAH8pIn8A3AA0i9eIyJMI7v6L7XOFYBg8FbgX+DDwTuB9BE/CQV97HO0HISKvA153lFt0HGcDIfXgQNTml7I/FtkfCCv1LH3TlE8LdRSSJ19xYifodBZVFzjiBKUrquoY8HXgElW9Q1UvVtWnA38D3BP7ichphLiD31DV2H6+jXGPqipwHfB/2LldmMfBYhEGgJFiu3EawduwHxi0vsX2Q835KlW9QFUvWM69O46z/pDqi6C7P7x2nh5e5VJ4pSnzPz3A/E8PrPY0HacjdDIrYat5ChCRbuD5wB0iss3aEuDdwMfs8yDwj8A7VfWbhaEeBs4Vka32+QXAT+34BkKgIsDLgZvNeLgRuFhEhizo8GLgRjv3NeuLXfuFlb1zx3EcZ73iWQmd3UoYBq4RkRLBALlOVb8oIm8WkTdan88Dn7bjNwGPBd4jIu+xtotVdbelOn5DROaBB4DftPNXA58RkbsJnoJXAqjqiIi8F/iO9ftjVR2x47cD14rI+4BbyeMVHMdxMqR8MQA6/fnQcEYoolQul5n78u2rNS2nk6jXSoAOGgaq+iNCXMDi9g8R0g8Xt7+PEDdwqLE+hnkWFrU3CAGMh7rmU8BBqiOqei8hhdFxHMdxnEW48qHjOM4RkJ5fASDdH5ybMjRNebh3NafkdJD16PpfadwwcBzHORb6hyg98dTVnoXjdAw3DBzHcRwHUIXUPQZuGDiO4ywF6bXEqMYEnHU6AM1PvBKA6muvXa1pOSuK6xiAl112HMdxHKeAGwaO4zjHgM5NgqagKaUtdUpb6rT++tWrPS1nJfDqioAbBo7jOEunXKjSXguZCfLz52VN7W+97UTPyHFWHI8xcBzHWQpmFEh9c1Y/IRoFybOe7EbBBmE9rvBXGjcMHMdxloKYg7WrjnTVw/HsBADaGKf0rLev0sSclUJd+RDwrQTHcRzHcQq4x8BxHGcJaBLWUTKfwtxUaJubDCf3PbJa0/r/27v3oKuq847j3x/3iEZuYlCMmEhM0VRUlNhJOxkQgkzrpcYKyShTM4PamDaTaadYY2M0f6i9mGbaRikmY1tjMU0c8RaiBMeMk1FACZcIAl4RB4q34CUkytM/9nMO25cDL+/LOe+58PvM7Dl7r7322uvh6HvWWWudta2ugti1q9mVaDr3GJiZmVmVewzMzPaDKvMJdu6AyrfK3xQ9BwwZ3KRaWV15jgHgHgMzs/2iQ85Dh5xX7A8aigYNhX79ig14/8HLef/By5tZRetAkkZIekjShnwdXiPPCZJWlrZfS/pqnrtW0sulczO7u6cbBmZmZqkFFziaByyJiPHAkjz+YJ0j1kfExIiYCJwGvAPcXcpyc+V8RDzQ3Q09lGBm1gP9hl9M/O4nxcG7+bPF/oPQ7328eZWyumjRhyidC3w2928HHgH29dvYqcCmiHihtzd0j4GZmVljjZK0vLTN7cG1R0bEKwD5Orqb/LOAO7ukXSlplaTv1RqK6Mo9BmZmPfX2a8XrwCEA9BvtZyV0igZNPtweEZP2dlLSw8BHapy6uic3kTQIOAe4qpT8XeB6IPL1n4BL91WOGwZmZr3Ub7gbBHbgIuKsvZ2TtFXSmIh4RdIYYNs+ijobeDIitpbKru5L+g/gvu7q46EEMzMzgKj/xMM6TD5cBMzJ/TnAPfvIO5suwwjZmKg4H1jT3Q3dY2Bm1kMa9oVmV8EapAXXMbgBuEvSl4AXgQsBJB0FLIiImXl8CDANuKzL9TdJmkgxlPB8jfN7cMPAzMysRUXEqxS/NOiavgWYWTp+BxhZI1+Px7s8lGBm1gC7Xry52VWwnoqWXMegz7lhYGbWCAMGNbsGZr3ioQQzMzOKQfh2/IZfb24YmJk1QL+jvtzsKlhP+SFKgIcSzMzMrMQ9BmZmZgBEKz4roc+5x8DMzMyq3GNgZmZGMflw165m16L53GNgZmZmVe4xMDMzAwj3GIAbBmZmZlVuGHgowczMzErcY2BmZkZOPvSvFd1jYGZmZru5x8DMzAw8+TC5YWBmZobXMajwUIKZmZlVucfAzMwMPJSQ3GNgZmZmVe4xMDMzS+4xcMPAzMwM8OTDCg8lmJmZWZV7DMzMzMCTD5N7DMzMzKzKPQZmZmZ4jkFFw3oMJA2R9ISkX0paK+mbmX6ypF9IWi3pXkkfzvRpklZk+gpJUzL9MEkrS9t2Sd/Oc4MlLZS0UdLjksaV7j9H0obc5pTSj8u8G/LaQY36NzAzM2s3jRxK2AlMiYiTgYnADEmfBhYA8yLiU8DdwN9k/u3An2T6HOC/ACJiR0RMrGzAC8CP85ovAa9HxPHAzcCNAJJGAN8AJgNnAN+QNDyvuRG4OSLGA69nGWZmdrDLOQb13tpNwxoGUXgrDwfmFsAJwKOZ/hBwQeZ/KiK2ZPpaYIikweUyJY0HRgM/z6Rzgdtz/3+BqZIEfA54KCJei4jX8z4z8tyUzEtee16dQjYzszYXEXXf2k1DJx9K6i9pJbCN4oP6cWANcE5muRA4psalFwBPRcTOLumzgYWx+1/6aOAlgIh4D3gTGFlOT5szbSTwRuYtp5uZmRkNbhhExPvZ/T8WOEPSScClwJclrQAOA35bvkbSiRTd/ZfVKHIWcGc5e63b9iJ9D5LmSlouaXmt82Zm1lkqkw89lNAHIuIN4BFgRkSsi4jpEXEaxYf8pko+SWMp5h1cEhGbymVIOhkYEBErSsmbyR4HSQOAw4HXyulpLLCFYh7DsMxbTq9V5/kRMSkiJvUuajMzs/bTyF8lHCFpWO5/CDgLWCdpdKb1A74O3JLHw4D7gasi4rEaRc7mg70FAIsoJioCfB74WQ4zLAamSxqekw6nA4vz3NLMS157Tz3iNTOzNufJh0BjewzGAEslrQKWUcwxuA+YLekZYB3Ft/XvZ/4rgeOBa0o/TRxdKu/P2LNhcBswUtJG4GvAPICIeA24Pu+7DLgu0wD+FvhaXjMyyzAzM3PDAFA7zpjsa5L8j2Rm1jpWNGKY9xMDhsR3PnxsvYvl7NefaUh9G8UrH5qZmeGVDyv8rAQzMzOrco+BmZkZ+OmKyQ0DMzMzPJRQ4aEEMzMzq3KPgZmZGXgoIbnHwMzMzKrcY2BmZpZ2edUa9xiYmZnZbu4xMDMzw79KqHDDwMzMDDz5MHkowczMrEVJulDSWkm7JO31eQuSZkhaL2mjpHml9BGSHpK0IV+Hd3dPNwzMzMzYPZTQYk9XXAP8KfDo3jJI6g/8G3A2MIHiKcYT8vQ8YElEjAeW5PE+uWFgZmbWoiLi6YhY3022M4CNEfFsRPwW+B/g3Dx3LnB77t8OnNfdPT3HwMzMLLXpHIOjgZdKx5uBybl/ZES8AhARr0ga3V1hbhjsn+3AC82uRMkoijp1qk6PDxxjJ+j0+KB1Yzy2EYU+x87FX+SZUQ0oeoik5aXj+RExv3Ig6WHgIzWuuzoi7tmP8lUjrdcrMrhhsB8i4ohm16FM0vKI2OsklHbX6fGBY+wEnR4fHBwxlkXEjCbd96wDLGIzcEzpeCywJfe3ShqTvQVjgG3dFeY5BmZmZu1tGTBe0nGSBgGzgEV5bhEwJ/fnAN32QLhhYGZm1qIknS9pM3AmcL+kxZl+lKQHACLiPeBKYDHwNHBXRKzNIm4ApknaAEzL433yUEJ7mt99lrbW6fGB6LlnhQAAByFJREFUY+wEnR4fHBwxtrSIuBu4u0b6FmBm6fgB4IEa+V4FpvbknorwEyPMzMys4KEEMzMzq3LDoIEkHSNpqaSnc0nLv8r0mktUSpomaYWk1fk6pVTWI7nc5crcRmf6YEkLcxnMxyWNK10zJ++xQdKcUvpxmXdDXjuoRWIcJGm+pGckrZN0QbNjrFd8kg4rvXcrJW2X9O1mx1fPGPPc7ExfJeknkkZ1YIwXZXxrJd1USm+n/07PKP23+EtJ55fKOi3j3ijpO5LU7Pisj0WEtwZtwBjg1Nw/DHiGYrnKm4B5mT4PuDH3TwGOyv2TgJdLZT0CTKpxj78Absn9WcDC3B8BPJuvw3N/eJ67C5iV+7cAV7RIjN8EvpX7/YBRzY6xnvF1KXcF8EfNjq+eMVLMWdpWet9uAq7tsBhHAi8CR+Tx7cDUZsfYi/gOAQaUrt1WOn6CYqKbgAeBs5sdn7e+3ZpegYNpo/iZyDRgPTAm08YA62vkFfAqMDiPH6F2w2AxcGbuD6BYjETAbODWUr5bM02Zp/JH4ExgcYvE+BIwtJVjPJD4SunjM1a1WnwHEiMwEPg/isVnlB8EczssxtOBh0vnLgb+vdVi7GF8xwFbs85jgHWlc9W6t1J83hq7eSihj2S32ynA43RZohKotUTlBcBTEbGzlPb97Pq7ptK9R2kpzCh+svImxbeaWktkHp3n3si85fQDdiAxShqWaddLelLSDyUd2Uox1uk9hOKP5sLIv5a0SHxwYDFGxO+AK4DVFIurTABu66QYgY3AJyWNkzSAYt35ysIyLRHj/sYnabKktRTv1+VZj6OzHl3r2jLxWeO5YdAHJB0K/Aj4akT8ej/ynwjcCFxWSv5iRHwK+MPcLq5kr1FE9CL9gNQhxgEUq3U9FhGnAr8A/rGSfS917rMY6/QeVswC7ixnr5Gn7d5DSQMpGganAEcBq4CrKtn3Uue2ijEiXqeIcSHwc+B5oPLB1/QYexJfRDweESdS9IJcJWlIN3VqenzWN9wwaLD8Y/kj4I6I+HEmb1WxNCXqskSlpLEUv1m9JCI2VdIj4uV83QH8gOJpWlBaCjO/wRwOvMbel8jcDgzLvOX0Zsf4KvAOu3+v+0Pg1FaIsV7vYZ47maJrdUUpuVPew4kAEbEpe0PuAv6gw2IkIu6NiMkRcSZFV/2GVoixp/GV4nkaeJtiLsXmrEfXujY9Pus7bhg0UHb33wY8HRH/XDpVc4nK7E6/H7gqIh4rlTNAu2d3DwT+mOIZ3V3L+jzws/yjvBiYLml4zkSeTjG+F8DSzPuB+zczxqzXvcBnM2kq8Ktmx1iv+Epm88HegqbGV+cYXwYmSKo8W2QaxSpsnRQj2v2LoOEUE/IWNDvGXsR3XOUDW9KxwAnA8zncsEPSp7PMS0p1aup7aH2oLyYyHKwb8BmKrrNVwMrcZlKMvS2h+KaxBBiR+b9O0XJfWdpGA0MpZrGvAtYC/wL0z2uGUHy73kgxm/hjpftfmukbgT8vpX8s827Mawc3O8Y8dyzwaJa1BPhos2OsZ3x5/lngk13u0Unv4eUUjYFVFA29kR0Y450UjdZfkTPumx1jL+K7mOJvyUrgSeC8UlmTKL54bAL+ld2TZJv6Hnrru80rH5qZmVmVhxLMzMysyg0DMzMzq3LDwMzMzKrcMDAzM7MqNwzMzMysyg0DMzMzq3LDwKzN5Dr970paWafyJkqa2YvrPp7P7nirHvUws9bghoFZe9oUERPrVNZEisVw9lBaznYPUSx9XK86mFmLcMPArIVIOl3SKklDJA2VtFbSSd1cM07SOkkLJK2RdIeksyQ9JmmDpDMy31BJ35O0TNJTks6VNAi4Drgov/1fJOlaSfMl/RT4T0n9Jf1DXrdKUq0HQ5lZh9jrtwEz63sRsUzSIuBbwIeA/46INd1cBnA8cCEwF1gGfIFimdxzgL+jeDzw1RTr21+azwJ4AngY+HtgUkRcCSDpWuA04DMR8a6kucCbEXG6pMHAY5J+GhHP1S1wM2sZbhiYtZ7rKD7cfwP85X5e81xErAaQtBZYEhEhaTUwLvNMB86R9Nd5PAT46F7KWxQR75au+31JlYfhHA6MB9wwMOtAbhiYtZ4RwKHAQIoP77f345qdpf1dpeNd7P7/XMAFEbG+fKGkyTXKK99TwFciYvF+1MPM2pznGJi1nvnANcAdwI11LHcx8JV8nC6STsn0HcBh3Vx3RT7yG0mfkDS0jvUysxbihoFZC5F0CfBeRPwAuAE4XdKUOhV/PUUvxCpJa/IYYCkwoTL5sMZ1CygeMfxkXncr7m0061h+7LJZm5E0DrgvIvb5a4W+IumtiDi02fUws/pwj4FZ+3kfOLxeCxz1VmWBI2BrM+thZvXlHgMzMzOrco+BmZmZVblhYGZmZlVuGJiZmVmVGwZmZmZW5YaBmZmZVf0/VNn0sTj45oEAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 576x576 with 2 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plt.figure(figsize = (8,8))\n",
     "ndvi_anomaly_output.plot(vmin=-1, vmax=1, cmap = RdYlGn)"
@@ -867,7 +1328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
+++ b/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
@@ -27,7 +27,7 @@
    "outputs": [],
    "source": [
     "# The dtip fork of datacude_utilities includes some updated requirements which we need for the notebook to run on the updated dask cluster\n",
-    "#!pip install git+https://github.com/dtip/datacube-utilities.git#egg=datacube_utilities\n",
+    "!pip install git+https://github.com/dtip/datacube-utilities.git#egg=datacube_utilities\n",
     "#!pip install git+https://github.com/SatelliteApplicationsCatapult/datacube-utilities.git#egg=datacube_utilities"
    ]
   },
@@ -961,7 +961,6 @@
    ],
    "source": [
     "%%time\n",
-    "# TODO check this\n",
     "baseline_composite = baseline_composite.where((baseline_composite != np.nan) & (water_composite_base == 0))\n",
     "analysis_composite = analysis_composite.where((analysis_composite != np.nan) & (water_composite_analysis == 0))"
    ]

--- a/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
+++ b/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
@@ -22,151 +22,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: datacube_utilities from git+https://github.com/SatelliteApplicationsCatapult/datacube-utilities.git#egg=datacube_utilities in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (0.0.1)\n",
-      "Requirement already satisfied: dask==2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2.0.0)\n",
-      "Requirement already satisfied: lcmap-pyccd==2017.08.18 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2017.8.18)\n",
-      "Requirement already satisfied: hdmedians==0.13 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.13)\n",
-      "Requirement already satisfied: folium==0.9.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.9.1)\n",
-      "Requirement already satisfied: scipy==1.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.3.0)\n",
-      "Requirement already satisfied: scikit-image==0.15.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.15.0)\n",
-      "Requirement already satisfied: distributed==2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2.0.1)\n",
-      "Requirement already satisfied: geopandas==0.5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: datacube==1.7 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.7)\n",
-      "Requirement already satisfied: ipyleaflet==0.10.8 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.10.8)\n",
-      "Requirement already satisfied: scikit-learn==0.21.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.21.2)\n",
-      "Requirement already satisfied: ruamel.yaml==0.15.96 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.15.96)\n",
-      "Requirement already satisfied: seaborn==0.9.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.9.0)\n",
-      "Requirement already satisfied: shapely==1.6.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.6.4)\n",
-      "Requirement already satisfied: rasterstats==0.13.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.13.1)\n",
-      "Requirement already satisfied: descartes==1.1.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.1.0)\n",
-      "Requirement already satisfied: matplotlib==3.1.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (3.1.0)\n",
-      "Requirement already satisfied: xarray>=0.13.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.15.1)\n",
-      "Requirement already satisfied: boto3==1.9.179 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.9.179)\n",
-      "Requirement already satisfied: click-plugins>=1.0.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (1.1.1)\n",
-      "Requirement already satisfied: PyYAML>=3.12 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (5.1)\n",
-      "Requirement already satisfied: click>=6.6 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (7.0)\n",
-      "Requirement already satisfied: cachetools>=2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (3.1.1)\n",
-      "Requirement already satisfied: numpy>=1.10.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (1.16.4)\n",
-      "Requirement already satisfied: Cython>=0.23 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from hdmedians==0.13->datacube_utilities) (0.29.15)\n",
-      "Requirement already satisfied: requests in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.9.1->datacube_utilities) (2.22.0)\n",
-      "Requirement already satisfied: branca>=0.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.9.1->datacube_utilities) (0.3.1)\n",
-      "Requirement already satisfied: jinja2>=2.9 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.9.1->datacube_utilities) (2.10.1)\n",
-      "Requirement already satisfied: networkx>=2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.15.0->datacube_utilities) (2.3)\n",
-      "Requirement already satisfied: pillow>=4.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.15.0->datacube_utilities) (6.0.0)\n",
-      "Requirement already satisfied: imageio>=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.15.0->datacube_utilities) (2.5.0)\n",
-      "Requirement already satisfied: PyWavelets>=0.4.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.15.0->datacube_utilities) (1.0.3)\n",
-      "Requirement already satisfied: toolz>=0.7.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (0.9.0)\n",
-      "Requirement already satisfied: six in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (1.12.0)\n",
-      "Requirement already satisfied: cloudpickle>=0.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (1.2.1)\n",
-      "Requirement already satisfied: psutil>=5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (5.6.3)\n",
-      "Requirement already satisfied: msgpack in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (0.6.1)\n",
-      "Requirement already satisfied: sortedcontainers!=2.0.0,!=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (2.1.0)\n",
-      "Requirement already satisfied: tornado>=5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (6.0.3)\n",
-      "Requirement already satisfied: zict>=0.1.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (1.0.0)\n",
-      "Requirement already satisfied: tblib in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.0.1->datacube_utilities) (1.4.0)\n",
-      "Requirement already satisfied: pyproj in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.5.0->datacube_utilities) (2.2.1)\n",
-      "Requirement already satisfied: pandas in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.5.0->datacube_utilities) (1.0.3)\n",
-      "Requirement already satisfied: fiona in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.5.0->datacube_utilities) (1.8.6)\n",
-      "Requirement already satisfied: affine in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.2.2)\n",
-      "Requirement already satisfied: python-dateutil in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.8.0)\n",
-      "Requirement already satisfied: jsonschema in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (3.0.1)\n",
-      "Requirement already satisfied: netcdf4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.5.1.2)\n",
-      "Requirement already satisfied: rasterio>=1.0.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.0.22)\n",
-      "Requirement already satisfied: singledispatch in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (3.4.0.3)\n",
-      "Requirement already satisfied: pypeg2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.15.2)\n",
-      "Requirement already satisfied: gdal>=1.9 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.4.1)\n",
-      "Requirement already satisfied: lark-parser>=0.6.7 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (0.8.2)\n",
-      "Requirement already satisfied: sqlalchemy in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.3.5)\n",
-      "Requirement already satisfied: psycopg2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.8.3)\n",
-      "Requirement already satisfied: traittypes<3,>=0.2.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.10.8->datacube_utilities) (0.2.1)\n",
-      "Requirement already satisfied: ipywidgets<8,>=7.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.10.8->datacube_utilities) (7.4.2)\n",
-      "Requirement already satisfied: joblib>=0.11 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-learn==0.21.2->datacube_utilities) (0.13.2)\n",
-      "Requirement already satisfied: cligj>=0.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.13.1->datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: simplejson in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.13.1->datacube_utilities) (3.16.1)\n",
-      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.1.0->datacube_utilities) (2.4.0)\n",
-      "Requirement already satisfied: cycler>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.1.0->datacube_utilities) (0.10.0)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.1.0->datacube_utilities) (1.1.0)\n",
-      "Requirement already satisfied: setuptools>=41.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from xarray>=0.13.0->datacube_utilities) (46.1.1)\n",
-      "Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.9.179->datacube_utilities) (0.9.4)\n",
-      "Requirement already satisfied: botocore<1.13.0,>=1.12.179 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.9.179->datacube_utilities) (1.12.179)\n",
-      "Requirement already satisfied: s3transfer<0.3.0,>=0.2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.9.179->datacube_utilities) (0.2.1)\n",
-      "Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (3.0.4)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (2019.6.16)\n",
-      "Requirement already satisfied: idna<2.9,>=2.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (2.8)\n",
-      "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.9.1->datacube_utilities) (1.24.3)\n",
-      "Requirement already satisfied: MarkupSafe>=0.23 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jinja2>=2.9->folium==0.9.1->datacube_utilities) (1.1.1)\n",
-      "Requirement already satisfied: decorator>=4.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from networkx>=2.0->scikit-image==0.15.0->datacube_utilities) (4.4.0)\n",
-      "Requirement already satisfied: heapdict in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from zict>=0.1.3->distributed==2.0.1->datacube_utilities) (1.0.0)\n",
-      "Requirement already satisfied: pytz>=2017.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pandas->geopandas==0.5.0->datacube_utilities) (2019.1)\n",
-      "Requirement already satisfied: attrs>=17 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from fiona->geopandas==0.5.0->datacube_utilities) (19.1.0)\n",
-      "Requirement already satisfied: munch in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from fiona->geopandas==0.5.0->datacube_utilities) (2.3.2)\n",
-      "Requirement already satisfied: pyrsistent>=0.14.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jsonschema->datacube==1.7->datacube_utilities) (0.15.2)\n",
-      "Requirement already satisfied: cftime in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from netcdf4->datacube==1.7->datacube_utilities) (1.0.3.4)\n",
-      "Requirement already satisfied: snuggs>=1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterio>=1.0.2->datacube==1.7->datacube_utilities) (1.4.6)\n",
-      "Requirement already satisfied: traitlets>=4.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from traittypes<3,>=0.2.1->ipyleaflet==0.10.8->datacube_utilities) (4.3.2)\n",
-      "Requirement already satisfied: widgetsnbextension~=3.4.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (3.4.2)\n",
-      "Requirement already satisfied: ipykernel>=4.5.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (5.1.1)\n",
-      "Requirement already satisfied: nbformat>=4.2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (4.4.0)\n",
-      "Requirement already satisfied: ipython>=4.0.0; python_version >= \"3.3\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (7.5.0)\n",
-      "Requirement already satisfied: docutils>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from botocore<1.13.0,>=1.12.179->boto3==1.9.179->datacube_utilities) (0.14)\n",
-      "Requirement already satisfied: ipython_genutils in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from traitlets>=4.2.2->traittypes<3,>=0.2.1->ipyleaflet==0.10.8->datacube_utilities) (0.2.0)\n",
-      "Requirement already satisfied: notebook>=4.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (5.7.8)\n",
-      "Requirement already satisfied: jupyter-client in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipykernel>=4.5.1->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (5.2.4)\n",
-      "Requirement already satisfied: jupyter_core in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbformat>=4.2.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (4.4.0)\n",
-      "Requirement already satisfied: prompt-toolkit<2.1.0,>=2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (2.0.9)\n",
-      "Requirement already satisfied: pygments in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (2.4.2)\n",
-      "Requirement already satisfied: pickleshare in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.7.5)\n",
-      "Requirement already satisfied: pexpect; sys_platform != \"win32\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (4.7.0)\n",
-      "Requirement already satisfied: jedi>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.14.0)\n",
-      "Requirement already satisfied: backcall in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.1.0)\n",
-      "Requirement already satisfied: Send2Trash in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (1.5.0)\n",
-      "Requirement already satisfied: nbconvert in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (5.5.0)\n",
-      "Requirement already satisfied: terminado>=0.8.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.8.2)\n",
-      "Requirement already satisfied: prometheus-client in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.7.1)\n",
-      "Requirement already satisfied: pyzmq>=17 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (18.0.2)\n",
-      "Requirement already satisfied: wcwidth in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from prompt-toolkit<2.1.0,>=2.0.0->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.1.7)\n",
-      "Requirement already satisfied: ptyprocess>=0.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pexpect; sys_platform != \"win32\"->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.6.0)\n",
-      "Requirement already satisfied: parso>=0.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jedi>=0.10->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: testpath in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.4.2)\n",
-      "Requirement already satisfied: pandocfilters>=1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (1.4.2)\n",
-      "Requirement already satisfied: entrypoints>=0.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.3)\n",
-      "Requirement already satisfied: bleach in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (3.1.0)\n",
-      "Requirement already satisfied: mistune>=0.8.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.8.4)\n",
-      "Requirement already satisfied: defusedxml in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: webencodings in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.4.0->ipywidgets<8,>=7.0.0->ipyleaflet==0.10.8->datacube_utilities) (0.5.1)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#!pip install git+https://github.com/dtip/datacube-utilities.git#egg=datacube_utilities\n",
-    "!pip install git+https://github.com/SatelliteApplicationsCatapult/datacube-utilities.git#egg=datacube_utilities"
+    "#!pip install git+https://github.com/SatelliteApplicationsCatapult/datacube-utilities.git#egg=datacube_utilities"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: xarray==0.13.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (0.13.0)\n",
-      "Requirement already satisfied: numpy>=1.12 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from xarray==0.13.0) (1.16.4)\n",
-      "Requirement already satisfied: pandas>=0.19.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from xarray==0.13.0) (0.24.2)\n",
-      "Requirement already satisfied: pytz>=2011k in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pandas>=0.19.2->xarray==0.13.0) (2019.1)\n",
-      "Requirement already satisfied: python-dateutil>=2.5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pandas>=0.19.2->xarray==0.13.0) (2.8.0)\n",
-      "Requirement already satisfied: six>=1.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from python-dateutil>=2.5.0->pandas>=0.19.2->xarray==0.13.0) (1.12.0)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We seem to be hitting an old xarray bug using v0.12.1. See https://github.com/pydata/xarray/issues/3171 and https://github.com/pydata/xarray/pull/3173\n",
     "# We want at least xarray version 0.13.0\n",
@@ -174,181 +42,120 @@
     "#!pip install dask --upgrade\n",
     "#!pip uninstall -y xarray dask\n",
     "#!pip install xarray==0.13.0\n",
-    "#!pip install blosc==1.8.1 pandas==0.24.2"
+    "#!pip install blosc==1.8.1 pandas==0.24.2\n",
+    "#!pip install blosc==1.8.3 cloudpickle==1.3.0 lz4==3.0.2 msgpack==1.0.0 numpy==1.18.1 toolz==0.10.0 tornado==6.0.4"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.13.0\n"
+      "0.15.0\n",
+      "2.12.0\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'scheduler': {'host': (('python', '3.6.7.final.0'),\n",
+       "{'scheduler': {'host': (('python', '3.6.10.final.0'),\n",
        "   ('python-bits', 64),\n",
        "   ('OS', 'Linux'),\n",
-       "   ('OS-release', '4.15.0-55-generic'),\n",
+       "   ('OS-release', '4.15.0-54-generic'),\n",
        "   ('machine', 'x86_64'),\n",
        "   ('processor', ''),\n",
        "   ('byteorder', 'little'),\n",
        "   ('LC_ALL', 'C.UTF-8'),\n",
-       "   ('LANG', 'C.UTF-8'),\n",
-       "   ('LOCALE', 'en_US.UTF-8')),\n",
-       "  'packages': {'required': (('dask', '2.0.0'),\n",
-       "    ('distributed', '2.0.1'),\n",
-       "    ('msgpack', '0.6.1'),\n",
-       "    ('cloudpickle', '1.2.1'),\n",
-       "    ('tornado', '6.0.3'),\n",
-       "    ('toolz', '0.9.0')),\n",
-       "   'optional': (('numpy', '1.16.4'),\n",
-       "    ('pandas', '0.24.2'),\n",
-       "    ('bokeh', '1.2.0'),\n",
-       "    ('lz4', None),\n",
-       "    ('dask_ml', None),\n",
-       "    ('blosc', '1.8.1'))}},\n",
-       " 'workers': {'tcp://10.244.1.72:41713': {'host': (('python', '3.6.7.final.0'),\n",
+       "   ('LANG', 'C.UTF-8')),\n",
+       "  'packages': {'dask': '2.12.0',\n",
+       "   'distributed': '2.12.0',\n",
+       "   'msgpack': '1.0.0',\n",
+       "   'cloudpickle': '1.3.0',\n",
+       "   'tornado': '6.0.4',\n",
+       "   'toolz': '0.10.0',\n",
+       "   'numpy': '1.18.1',\n",
+       "   'lz4': '3.0.2',\n",
+       "   'blosc': '1.8.3'}},\n",
+       " 'workers': {'tcp://10.244.1.166:34261': {'host': (('python',\n",
+       "     '3.6.10.final.0'),\n",
        "    ('python-bits', 64),\n",
        "    ('OS', 'Linux'),\n",
-       "    ('OS-release', '4.15.0-55-generic'),\n",
+       "    ('OS-release', '4.15.0-54-generic'),\n",
        "    ('machine', 'x86_64'),\n",
        "    ('processor', ''),\n",
        "    ('byteorder', 'little'),\n",
        "    ('LC_ALL', 'C.UTF-8'),\n",
-       "    ('LANG', 'C.UTF-8'),\n",
-       "    ('LOCALE', 'en_US.UTF-8')),\n",
-       "   'packages': {'required': (('dask', '2.0.0'),\n",
-       "     ('distributed', '2.0.1'),\n",
-       "     ('msgpack', '0.6.1'),\n",
-       "     ('cloudpickle', '1.2.1'),\n",
-       "     ('tornado', '6.0.3'),\n",
-       "     ('toolz', '0.9.0')),\n",
-       "    'optional': (('numpy', '1.16.4'),\n",
-       "     ('pandas', '0.24.2'),\n",
-       "     ('bokeh', '1.2.0'),\n",
-       "     ('lz4', None),\n",
-       "     ('dask_ml', None),\n",
-       "     ('blosc', '1.8.1'))}},\n",
-       "  'tcp://10.244.2.109:38699': {'host': (('python', '3.6.7.final.0'),\n",
+       "    ('LANG', 'C.UTF-8')),\n",
+       "   'packages': {'dask': '2.12.0',\n",
+       "    'distributed': '2.12.0',\n",
+       "    'msgpack': '1.0.0',\n",
+       "    'cloudpickle': '1.3.0',\n",
+       "    'tornado': '6.0.4',\n",
+       "    'toolz': '0.10.0',\n",
+       "    'numpy': '1.18.1',\n",
+       "    'lz4': '3.0.2',\n",
+       "    'blosc': '1.8.3'}},\n",
+       "  'tcp://10.244.2.201:43843': {'host': (('python', '3.6.10.final.0'),\n",
        "    ('python-bits', 64),\n",
        "    ('OS', 'Linux'),\n",
-       "    ('OS-release', '4.15.0-55-generic'),\n",
+       "    ('OS-release', '4.15.0-54-generic'),\n",
        "    ('machine', 'x86_64'),\n",
        "    ('processor', ''),\n",
        "    ('byteorder', 'little'),\n",
        "    ('LC_ALL', 'C.UTF-8'),\n",
-       "    ('LANG', 'C.UTF-8'),\n",
-       "    ('LOCALE', 'en_US.UTF-8')),\n",
-       "   'packages': {'required': (('dask', '2.0.0'),\n",
-       "     ('distributed', '2.0.1'),\n",
-       "     ('msgpack', '0.6.1'),\n",
-       "     ('cloudpickle', '1.2.1'),\n",
-       "     ('tornado', '6.0.3'),\n",
-       "     ('toolz', '0.9.0')),\n",
-       "    'optional': (('numpy', '1.16.4'),\n",
-       "     ('pandas', '0.24.2'),\n",
-       "     ('bokeh', '1.2.0'),\n",
-       "     ('lz4', None),\n",
-       "     ('dask_ml', None),\n",
-       "     ('blosc', '1.8.1'))}},\n",
-       "  'tcp://10.244.3.103:40397': {'host': (('python', '3.6.7.final.0'),\n",
+       "    ('LANG', 'C.UTF-8')),\n",
+       "   'packages': {'dask': '2.12.0',\n",
+       "    'distributed': '2.12.0',\n",
+       "    'msgpack': '1.0.0',\n",
+       "    'cloudpickle': '1.3.0',\n",
+       "    'tornado': '6.0.4',\n",
+       "    'toolz': '0.10.0',\n",
+       "    'numpy': '1.18.1',\n",
+       "    'lz4': '3.0.2',\n",
+       "    'blosc': '1.8.3'}},\n",
+       "  'tcp://10.244.3.182:34655': {'host': (('python', '3.6.10.final.0'),\n",
        "    ('python-bits', 64),\n",
        "    ('OS', 'Linux'),\n",
-       "    ('OS-release', '4.15.0-55-generic'),\n",
+       "    ('OS-release', '4.15.0-54-generic'),\n",
        "    ('machine', 'x86_64'),\n",
        "    ('processor', ''),\n",
        "    ('byteorder', 'little'),\n",
        "    ('LC_ALL', 'C.UTF-8'),\n",
-       "    ('LANG', 'C.UTF-8'),\n",
-       "    ('LOCALE', 'en_US.UTF-8')),\n",
-       "   'packages': {'required': (('dask', '2.0.0'),\n",
-       "     ('distributed', '2.0.1'),\n",
-       "     ('msgpack', '0.6.1'),\n",
-       "     ('cloudpickle', '1.2.1'),\n",
-       "     ('tornado', '6.0.3'),\n",
-       "     ('toolz', '0.9.0')),\n",
-       "    'optional': (('numpy', '1.16.4'),\n",
-       "     ('pandas', '0.24.2'),\n",
-       "     ('bokeh', '1.2.0'),\n",
-       "     ('lz4', None),\n",
-       "     ('dask_ml', None),\n",
-       "     ('blosc', '1.8.1'))}},\n",
-       "  'tcp://10.244.4.91:35177': {'host': (('python', '3.6.7.final.0'),\n",
-       "    ('python-bits', 64),\n",
-       "    ('OS', 'Linux'),\n",
-       "    ('OS-release', '4.15.0-55-generic'),\n",
-       "    ('machine', 'x86_64'),\n",
-       "    ('processor', ''),\n",
-       "    ('byteorder', 'little'),\n",
-       "    ('LC_ALL', 'C.UTF-8'),\n",
-       "    ('LANG', 'C.UTF-8'),\n",
-       "    ('LOCALE', 'en_US.UTF-8')),\n",
-       "   'packages': {'required': (('dask', '2.0.0'),\n",
-       "     ('distributed', '2.0.1'),\n",
-       "     ('msgpack', '0.6.1'),\n",
-       "     ('cloudpickle', '1.2.1'),\n",
-       "     ('tornado', '6.0.3'),\n",
-       "     ('toolz', '0.9.0')),\n",
-       "    'optional': (('numpy', '1.16.4'),\n",
-       "     ('pandas', '0.24.2'),\n",
-       "     ('bokeh', '1.2.0'),\n",
-       "     ('lz4', None),\n",
-       "     ('dask_ml', None),\n",
-       "     ('blosc', '1.8.1'))}},\n",
-       "  'tcp://10.244.5.72:36379': {'host': (('python', '3.6.7.final.0'),\n",
-       "    ('python-bits', 64),\n",
-       "    ('OS', 'Linux'),\n",
-       "    ('OS-release', '4.15.0-55-generic'),\n",
-       "    ('machine', 'x86_64'),\n",
-       "    ('processor', ''),\n",
-       "    ('byteorder', 'little'),\n",
-       "    ('LC_ALL', 'C.UTF-8'),\n",
-       "    ('LANG', 'C.UTF-8'),\n",
-       "    ('LOCALE', 'en_US.UTF-8')),\n",
-       "   'packages': {'required': (('dask', '2.0.0'),\n",
-       "     ('distributed', '2.0.1'),\n",
-       "     ('msgpack', '0.6.1'),\n",
-       "     ('cloudpickle', '1.2.1'),\n",
-       "     ('tornado', '6.0.3'),\n",
-       "     ('toolz', '0.9.0')),\n",
-       "    'optional': (('numpy', '1.16.4'),\n",
-       "     ('pandas', '0.24.2'),\n",
-       "     ('bokeh', '1.2.0'),\n",
-       "     ('lz4', None),\n",
-       "     ('dask_ml', None),\n",
-       "     ('blosc', '1.8.1'))}}},\n",
+       "    ('LANG', 'C.UTF-8')),\n",
+       "   'packages': {'dask': '2.12.0',\n",
+       "    'distributed': '2.12.0',\n",
+       "    'msgpack': '1.0.0',\n",
+       "    'cloudpickle': '1.3.0',\n",
+       "    'tornado': '6.0.4',\n",
+       "    'toolz': '0.10.0',\n",
+       "    'numpy': '1.18.1',\n",
+       "    'lz4': '3.0.2',\n",
+       "    'blosc': '1.8.3'}}},\n",
        " 'client': {'host': [('python', '3.6.7.final.0'),\n",
        "   ('python-bits', 64),\n",
        "   ('OS', 'Linux'),\n",
-       "   ('OS-release', '4.15.0-55-generic'),\n",
+       "   ('OS-release', '4.15.0-54-generic'),\n",
        "   ('machine', 'x86_64'),\n",
        "   ('processor', 'x86_64'),\n",
        "   ('byteorder', 'little'),\n",
        "   ('LC_ALL', 'en_US.UTF-8'),\n",
-       "   ('LANG', 'en_US.UTF-8'),\n",
-       "   ('LOCALE', 'en_US.UTF-8')],\n",
-       "  'packages': {'required': [('dask', '2.0.0'),\n",
-       "    ('distributed', '2.0.1'),\n",
-       "    ('msgpack', '0.6.1'),\n",
-       "    ('cloudpickle', '1.2.1'),\n",
-       "    ('tornado', '6.0.3'),\n",
-       "    ('toolz', '0.9.0')],\n",
-       "   'optional': [('numpy', '1.16.4'),\n",
-       "    ('pandas', '0.24.2'),\n",
-       "    ('bokeh', '1.2.0'),\n",
-       "    ('lz4', None),\n",
-       "    ('dask_ml', None),\n",
-       "    ('blosc', '1.8.1')]}}}"
+       "   ('LANG', 'en_US.UTF-8')],\n",
+       "  'packages': {'dask': '2.12.0',\n",
+       "   'distributed': '2.12.0',\n",
+       "   'msgpack': '1.0.0',\n",
+       "   'cloudpickle': '1.3.0',\n",
+       "   'tornado': '6.0.4',\n",
+       "   'toolz': '0.10.0',\n",
+       "   'numpy': '1.18.1',\n",
+       "   'lz4': '3.0.2',\n",
+       "   'blosc': '1.8.3'}}}"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -385,6 +192,7 @@
     "CMAP = \"Blues\"\n",
     "\n",
     "print(xr.__version__)\n",
+    "print(dask.__version__)\n",
     "\n",
     "client = Client('dask-scheduler.dask.svc.cluster.local:8786')\n",
     "#client = Client(n_workers=2, threads_per_worker=2, memory_limit='1GB')\n",
@@ -393,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -439,7 +247,7 @@
        "Datacube<index=Index<db=PostgresDb<engine=Engine(postgresql://postgres:***@datacubedb-postgresql.datacubedb.svc.cluster.local:5432/datacube)>>>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -458,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,15 +313,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 22.4 ms, sys: 3.11 ms, total: 25.5 ms\n",
-      "Wall time: 28.6 ms\n"
+      "CPU times: user 16.7 ms, sys: 7.14 ms, total: 23.9 ms\n",
+      "Wall time: 22.7 ms\n"
      ]
     }
    ],
@@ -524,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "scrolled": false
    },
@@ -533,8 +341,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8 µs, sys: 1 µs, total: 9 µs\n",
-      "Wall time: 17.9 µs\n"
+      "CPU times: user 7 µs, sys: 2 µs, total: 9 µs\n",
+      "Wall time: 16.9 µs\n"
      ]
     }
    ],
@@ -546,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -557,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -567,15 +375,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 253 ms, sys: 34.8 ms, total: 288 ms\n",
-      "Wall time: 291 ms\n"
+      "CPU times: user 167 ms, sys: 11.9 ms, total: 179 ms\n",
+      "Wall time: 179 ms\n"
      ]
     }
    ],
@@ -587,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -604,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -640,15 +448,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 16 µs, sys: 3 µs, total: 19 µs\n",
-      "Wall time: 27.7 µs\n"
+      "CPU times: user 16 µs, sys: 5 µs, total: 21 µs\n",
+      "Wall time: 28.1 µs\n"
      ]
     }
    ],
@@ -660,7 +468,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -690,8 +498,8 @@
      "output_type": "stream",
      "text": [
       "(datetime.date(2015, 3, 1), datetime.date(2015, 9, 1))\n",
-      "CPU times: user 4.15 ms, sys: 0 ns, total: 4.15 ms\n",
-      "Wall time: 3.73 ms\n"
+      "CPU times: user 4.36 ms, sys: 95 µs, total: 4.45 ms\n",
+      "Wall time: 3.92 ms\n"
      ]
     }
    ],
@@ -721,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -745,11 +553,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<pre>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:   (time: 12, x: 210, y: 259)\n",
+       "Coordinates:\n",
+       "  * time      (time) datetime64[ns] 2015-03-07T22:06:18 ... 2015-08-30T22:06:26\n",
+       "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
+       "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
+       "Data variables:\n",
+       "    green     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    red       (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    blue      (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    nir       (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir1     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir2     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    pixel_qa  (time, y, x) uint16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "Attributes:\n",
+       "    crs:      EPSG:3460</pre>"
+      ],
       "text/plain": [
        "<xarray.Dataset>\n",
        "Dimensions:   (time: 12, x: 210, y: 259)\n",
@@ -769,7 +595,7 @@
        "    crs:      EPSG:3460"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -788,11 +614,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<pre>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:   (time: 12, x: 210, y: 259)\n",
+       "Coordinates:\n",
+       "  * time      (time) datetime64[ns] 2016-03-09T22:06:29 ... 2016-09-01T22:06:49\n",
+       "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
+       "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
+       "Data variables:\n",
+       "    green     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    red       (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    blue      (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    nir       (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir1     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir2     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    pixel_qa  (time, y, x) uint16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "Attributes:\n",
+       "    crs:      EPSG:3460</pre>"
+      ],
       "text/plain": [
        "<xarray.Dataset>\n",
        "Dimensions:   (time: 12, x: 210, y: 259)\n",
@@ -812,7 +656,7 @@
        "    crs:      EPSG:3460"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -831,15 +675,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 673 ms, sys: 19.6 ms, total: 693 ms\n",
-      "Wall time: 852 ms\n"
+      "CPU times: user 771 ms, sys: 30.6 ms, total: 801 ms\n",
+      "Wall time: 851 ms\n"
      ]
     }
    ],
@@ -856,15 +700,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 644 ms, sys: 20.2 ms, total: 665 ms\n",
-      "Wall time: 736 ms\n"
+      "CPU times: user 655 ms, sys: 27.7 ms, total: 682 ms\n",
+      "Wall time: 729 ms\n"
      ]
     }
    ],
@@ -888,7 +732,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -905,7 +749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -915,7 +759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -934,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -974,15 +818,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 117 ms, sys: 740 µs, total: 118 ms\n",
-      "Wall time: 126 ms\n"
+      "CPU times: user 134 ms, sys: 4.44 ms, total: 138 ms\n",
+      "Wall time: 137 ms\n"
      ]
     }
    ],
@@ -994,11 +838,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<pre>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:   (time: 12, x: 210, y: 259)\n",
+       "Coordinates:\n",
+       "  * time      (time) datetime64[ns] 2015-03-07T22:06:18 ... 2015-08-30T22:06:26\n",
+       "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
+       "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
+       "Data variables:\n",
+       "    green     (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    red       (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    blue      (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    nir       (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir1     (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir2     (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    pixel_qa  (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "Attributes:\n",
+       "    crs:      EPSG:3460</pre>"
+      ],
       "text/plain": [
        "<xarray.Dataset>\n",
        "Dimensions:   (time: 12, x: 210, y: 259)\n",
@@ -1018,7 +880,7 @@
        "    crs:      EPSG:3460"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1043,7 +905,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1055,7 +917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1064,16 +926,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Delayed('create_median_mosaic-2d28ddb4-e7d4-48f7-a672-cd6f2b739ede')"
+       "Delayed('create_median_mosaic-848e65a8-c553-4374-8292-1a4cfb768fcd')"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1098,15 +960,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 23.9 ms, sys: 4 µs, total: 23.9 ms\n",
-      "Wall time: 30.4 ms\n"
+      "CPU times: user 22.3 ms, sys: 542 µs, total: 22.8 ms\n",
+      "Wall time: 22.2 ms\n"
      ]
     }
    ],
@@ -1118,15 +980,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 33.1 ms, sys: 168 µs, total: 33.3 ms\n",
-      "Wall time: 32.3 ms\n"
+      "CPU times: user 38.1 ms, sys: 499 µs, total: 38.6 ms\n",
+      "Wall time: 37.4 ms\n"
      ]
     }
    ],
@@ -1138,14 +1000,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 10.5 ms, sys: 0 ns, total: 10.5 ms\n",
+      "CPU times: user 14.8 ms, sys: 3.82 ms, total: 18.6 ms\n",
       "Wall time: 17.6 ms\n"
      ]
     }
@@ -1167,7 +1029,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1180,7 +1042,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1197,15 +1059,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.23 ms, sys: 0 ns, total: 2.23 ms\n",
-      "Wall time: 2.24 ms\n"
+      "CPU times: user 2.21 ms, sys: 0 ns, total: 2.21 ms\n",
+      "Wall time: 2.23 ms\n"
      ]
     }
    ],
@@ -1218,17 +1080,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.13.0\n",
-      "2.0.0\n",
-      "CPU times: user 593 µs, sys: 118 µs, total: 711 µs\n",
-      "Wall time: 644 µs\n"
+      "0.15.0\n",
+      "2.12.0\n",
+      "CPU times: user 518 µs, sys: 128 µs, total: 646 µs\n",
+      "Wall time: 587 µs\n"
      ]
     }
    ],
@@ -1243,58 +1105,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "distributed.protocol.pickle - INFO - Failed to deserialize b'\\x80\\x04\\x95_\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x8c\\x08builtins\\x94\\x8c\\x08KeyError\\x94\\x93\\x94\\x8c\\x11xarray.core.utils\\x94\\x8c\\nReprObject\\x94\\x93\\x94)\\x81\\x94}\\x94\\x8c\\x06_value\\x94\\x8c\\x0c<this-array>\\x94sb\\x85\\x94R\\x94.'\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/pickle.py\", line 61, in loads\n",
-      "    return pickle.loads(x)\n",
-      "AttributeError: 'ReprObject' object has no attribute '__dict__'\n",
-      "distributed.protocol.core - CRITICAL - Failed to deserialize\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/core.py\", line 126, in loads\n",
-      "    value = _deserialize(head, fs, deserializers=deserializers)\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/serialize.py\", line 190, in deserialize\n",
-      "    return loads(header, frames)\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/serialize.py\", line 64, in pickle_loads\n",
-      "    return pickle.loads(b\"\".join(frames))\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/pickle.py\", line 61, in loads\n",
-      "    return pickle.loads(x)\n",
-      "AttributeError: 'ReprObject' object has no attribute '__dict__'\n",
-      "distributed.utils - ERROR - 'ReprObject' object has no attribute '__dict__'\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/utils.py\", line 713, in log_errors\n",
-      "    yield\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/client.py\", line 1130, in _handle_report\n",
-      "    msgs = yield self.scheduler_comm.comm.read()\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/tornado/gen.py\", line 735, in run\n",
-      "    value = future.result()\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/tornado/gen.py\", line 742, in run\n",
-      "    yielded = self.gen.throw(*exc_info)  # type: ignore\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/comm/tcp.py\", line 218, in read\n",
-      "    frames, deserialize=self.deserialize, deserializers=deserializers\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/tornado/gen.py\", line 735, in run\n",
-      "    value = future.result()\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/tornado/gen.py\", line 209, in wrapper\n",
-      "    yielded = next(result)\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/comm/utils.py\", line 85, in from_frames\n",
-      "    res = _from_frames()\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/comm/utils.py\", line 71, in _from_frames\n",
-      "    frames, deserialize=deserialize, deserializers=deserializers\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/core.py\", line 126, in loads\n",
-      "    value = _deserialize(head, fs, deserializers=deserializers)\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/serialize.py\", line 190, in deserialize\n",
-      "    return loads(header, frames)\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/serialize.py\", line 64, in pickle_loads\n",
-      "    return pickle.loads(b\"\".join(frames))\n",
-      "  File \"/opt/conda/envs/cubeenv/lib/python3.6/site-packages/distributed/protocol/pickle.py\", line 61, in loads\n",
-      "    return pickle.loads(x)\n",
-      "AttributeError: 'ReprObject' object has no attribute '__dict__'\n"
+      "CPU times: user 1.15 s, sys: 32 ms, total: 1.18 s\n",
+      "Wall time: 1min 22s\n"
      ]
     }
    ],
@@ -1318,9 +1137,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.QuadMesh at 0x7f7338ffd588>"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfYAAAHrCAYAAAA9o7/5AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nOy9e5xlWVXn+Vvnvm/ceEdkZuSjst5FQYkgNMqoA9IN0nYLCiNT3Yow48A4ouNHW8emtWEanMYHjEMrwhQ0Ldi2NFMqXSIPSykabQUpEOrBq4qqyspHZGS8Xzdu3HvuWfPHXmuvc29kkVUZEZkZkev7+eTn3jiPffY5kZnrrLXX+i1iZjiO4ziOsz9ILvcEHMdxHMfZOdywO47jOM4+wg274ziO4+wj3LA7juM4zj7CDbvjOI7j7CPcsDuO4zjOPuKqMexE9H4iOkdEDzzJ419FRF8hogeJ6D/t9vwcx3EcZyegq6WOnYj+ewBrAD7IzLdd4NibAHwYwIuYeZGIDjDzuUsxT8dxHMfZDleNx87MnwGwkN9GRDcQ0SeI6AtE9FdE9DTZ9ToA72LmRTnXjbrjOI6zJ7hqDPsTcAeAn2Hm5wD4BQC/K9tvBnAzEf03IvosEb30ss3QcRzHcZ4Cxcs9gcsFETUA/HcA/j8i0s0V+SwCuAnACwEcBfAZIvo2Zl661PN0HMdxnKfCVWvYEaIVS8z8rPPsOwXgc8zcAfAoEX0DwdB//lJO0HEcx3GeKldtKJ6ZVxCM9o8AAAW+XXZ/BMFbBxFNIITmH7kc83Qcx3Gcp8JVY9iJ6A8B/C2AW4joFBH9BIAfBfATRPRlAA8CeLkc/kkA80T0FQD3APhFZp6/HPN2HMdxrmwuVE4tjuO/I6KHieg+IvqO3L7XENFD8uc1OzKfq6XczXEcx3F2gwuVUxPRDwD4GQA/AOA7AbyTmb+TiMYA3AvguQAYwBcAPEcrsi6Wq8ZjdxzHcZzd4Hzl1H28HMHoMzN/FsAIEU0B+H4AdzPzghjzuwFsuwrLDbvjOI7j7C5HAJzM/XxKtj3R9m1xVWTFE5GvN1wmnvPs64FE/5rJr6GzCbQ3w/dutuUcXm8DAGigDAD4wkOzuz1Nx3EuLXPMPLnTg9I1I4xWutPDArPrDwJo5bbcwcx37PyFdoarwrA7l4/Pf/F9oEyMdzcYbD77dfDfS47JUAMAQIMNIAl6ArzeDIfffwoAUP6pD1/CGTuOcwk4sSujtlLgld9SMfzieM/nWsz83G2McBrAsdzPR2XbaUgFVm77p7dxHQAeinccx3H2EZTQjv/ZAe4C8OOSHf9dAJaZeRqhAuslRDRKRKMAXiLbtoV77M6u0M3+wn4geX/shEgWn54GTR0I28olO65elcPD8YXjowCA9A9ejeKP/v7uTthxHOcikXLqFwKYIKJTAN4MoAQAzPweAB9DyIh/GEATwP8k+xaI6K0w8bO3MPO3SsJ7Urhhd3aFjEP4vZjl1tBlrZ0mx4BU1sHUsGey/t7uANWyHB/elNsPzqH7R68FABRe+Xu7OW3HcfY4O+Rh93ChJC1m/mcX2M8A3vAE+94P4P0XObXz4qF458qh3bncM3Acx9nzuMfu7Ci8/sfyTd4ZOQXaIRkOaVs+061GvFYDWpIpXw69eGh0GABQ+e5r0D2xLb0Gx3GuBmh3PPa9hht2x3EcZ9/ght0N+66S8afCl+mvIjl83uWV/YeuqWvCXKEMZGu9x9QHgKWzvdvaHaAlHr1+ajLdsdtQnDwTDnvP/wgAKP/kf97xqTuO4+wHfI19l+DlDwEAaM0SHLMvvelyTeeSwCtSb16U5DfOJ86Fv2rcWrbjV9fDFzXkAHhzs+cT1YqNceQwAKAwWdvBWTuOs18gEIh2/s9eww37LtBv1PmrX7tqjXqGbKtRb29uNerN1hMb9VJ1i1Hv/unrdulOHMdx9jYeit8FaPh2AAA3PxI21Gvo/NcHAeS89mIBdOyW8F3KwHj5dPjx6M9eusnuFPWR8KkheDHsCRUtaW7+XNi1vBrD7FbaloDSbvjeqIfP2kD4XJoFllblOuG8bG4tGvfCD7535+/HcZy9hyfPAXDD7jiO4+wj3LC7Yd9VqP5DAIDssd9E6QXioao3mhC4syHHBYU19dR55cOgoVdd2slug+z0b+d+EOEZXV9vN8GrM+G7iNHQ1CSg3nmxYOcuSKi+GZ5L9NKLBXBXjpfzkpEa0seWwiXeGyIk5dd9aGduyHEcZw/jht1xHMfZH3goHoAb9l0lm353+FJt2Br0xkr4pCR2O1PPPq7Jp23sBWIC28wMMHY8fC9JZCKfEd+WbocrUvZWLpmnXpUM99w983zwxFWwhq47Gv+xsgrblEso3RSumd330M7ckOM4zj7ADftuItngaDdB9XEAAGtv8uYSsBj6jGeP/WbY98iXw2m3vfnSzvMp0nr7D2/dyL191VkMPFESVeZ4NlQJ0PAgcGAsHFiQ5LluGtu1RlU60Y/nR0+BJsdlW+469ZBcl9wcDHz37p9G4cW/Ew67LzzD5Jn/5iLu0HGcvYp77G7YHcdxnH0CYcfarO5p3LDvJmVJlNtYAW9KIpi0LkVzPSaH8eIpAEDhH7/nUs/wKdP9o9fGMDpvSPh8dR2koXT11PPtkBqDYdukeOnFgkUzNiU8nxRBRw6G72viuavHrp48AKpJqL9eBebmw36piafjh5E98uth/7kQHUj/4NXhkt721XGcq4RdE6ghoioR/R0RfZmIHiSiLTFRIjpORH9JRPcR0aeJ6Ghu+xeJ6Ety7k+e59y7iOiB3Zq/4ziOs8eQ5Lmd/rPX2E2PfRPAi5h5jYhKAP6aiD7OzJ/NHfN2AB9k5g8Q0YsAvA3AqwFMA3g+M28SUQPAA0R0FzOfAQAiegWAPgHyKwdNguMNk09FS5Lm1sRzb3eshGsPQd/5bPCJkwAAfiTovSdHDoYEQaCnzA1ASBAcEE99TLu7dW0dXb3ziXFgQBIMG3J8N5TO0cy09W1XioU4Bk1Nhm0DgyGRD+bl04HQIa778Z8ERoYAAIXn/8bF3bzjOM4eYNcMuzSWV+Nbkj/9/eqfDuDn5fs9AD4i5+bTwivIRRbE0P88gNcD+PCOT3wnUINUDsldzBmwMB32SVga3RQkNe0s9dud3/8xAEDp1f/xEk72yaHtWLm5CKoEqddkTJThioW4xBBfZtZFI58zy5TXtqwZA/oWrAa7VAVVh+N3AODlaTtPs+ijKt0QUJSwvzzncH0Jy0u9u748UakEDIXjNFyfXP9LT/k5OI5zZbMXPeydZle14omoQERfAnAOwN3M/Lm+Q74M4BXy/YcBDBLRuJx7jIjuA3ASwK+rtw7grQDeAaAJx3Ecx3F62NXkOWbuAngWEY0A+BMiuo2Z8+vivwDgd4jotQA+A+A0gK6cexLAM4noMICPENGdAKYA3MDMP0dE136raxPR6xG8+kuPqq+pbnqWWr12LYSbqVAy5bkjEp4/900AIeHrSkn24tZHwxdNdtM6/DzNVoxSYCXowWNBjisWAEiSoCbBpd1Q8gYAY0F1D9UGUJFwfleT8hbDeZttkGrLyzOlyqAdn6+dH50K36UsjtbsmlofT5VQYtf5/R9D+kjYVnvzR7fc1uY7XynPIHj91V/6yNZ7dxznimIvdmPbaS5JVjwzLxHRPQBeCuCB3PYzEI9dQuyvZOalvnPPSJLc9wKYBPBcInpM5n6AiD7NzC88zzXvAHCHjN2/BOA4juPsN1x5DsAuGnYimgTQEaNeA/BiAL/ed8wEgAVmzgC8EcD7ZftRAPPMvEFEowC+B8BvMfOdAN4tx1wL4KPnM+qXk2z63datrRnKsdBNgUpYG6ZCLglsVlYXjl0HACjouvD0uVBWBqDwyt/b9Tl/K9JS8G6Lqh5XqQNp2nMMzy8C+Hr4riI0B1VQhuPxNC7Jca22rZWLIh/VRm28trR0bQzLvtXQEQ4AaQlcYwKkLWIzmw8Vw/o/69r9kHj19UHQkqz7y3ySayZRvvZAGOKf/HI4b2YOvCqRlFoYgzdCkl76oR9H8fYPPsGTchzHuTLYTY99CsAHiKiAsJb/YWb+KBG9BcC9zHwXgBcCeJt41J8B8AY591YA75DtBODtzHz/Ls5156g2zNCoylyWmbHvqqpaaglkkkFOt3x7+Pm6deDRhwEA3XtCY5jC971z9+feR+ixLiH4Qpg/1cfBQxJu16z+tSY4E6OpynDa5GWwEXu004Co76WbIZQOWBg9SYIaHwAsh2z7mDmf5FJB4vgtk6GVuYESeynQZ5/I8Z0W0BAjr+ctr8Z+8FGqNs39XqQfPC9KYmCzE8PzlZ/9o/7H5TjOZcYFagK7mRV/H4Bnn2f7m3Lf7wRw53mOuRvAMy8w/mMAbtv2RB3HcRxnH+HKczuEti4lKpjXSDlvVzxIDcVztw3UJKFOS8U0ma4xCT4mDWJOPg4A6H7yp0CjITSdPO9tu3ov3P2L8Dn3TUAU86gkcy3XQUduCt8nJOlvZT7Wo/NpqSOfmQvnTV0LGj0WjtOmN52W3bO2dG03ASlVi155U45ZXDbvfVC87qS4NUmxtWTKfoW+v9rtTWAwhPtpSBTukgQ4OyfzCNfmjQ6y1TDPQi1EGpLrDsjxFNXwNn/7RwAAxWtHUPjB9255ho7jXAZ8jR2AG3bHcRxnH+GG3Q37tuHVsJLAafC2mbtb1dcqjd51YiAk1G2KYMuKeKoiVINbhs3zPHIYAECNOvjRUzs///TPgbXgtWZf/VLY9uBfhZ31munCq3ocd0GNoPRGtaDkxu0mUA7r0ZgO6+80bslwUQ9ePewsM/GZhVDShmLBxGpGxaMuy7r94rKVx2nS3eYaWJ+Reuyri/acayJa05RnWx+IHfZ67r8j6nWDJnJDLSmzEy385Lk3hx1JAkyfBgCUvs9WgVzwxnGcKwk37NuEF04AAGgiZLZze31LC9OYKAbYvkIxSKAC1gxmXQzV0mkzUOsS7j5wFCTKbdlngwHh5VXQM24J+yV8nVzzc09q3tnsvw+ff/sJk2bVMLfS2rQkOKU+Yi8dmvhWKANSG05TErY+Iv3ZkyQadG6KEV+etXC7qtFVK7ZNa+XluVCtCoyJKp2G5PNIljsvrsQa9bgUMCAvApPHbB7TD8vnrLWUTTXpjlB42lEZT160lqW6odW2rP/j4YULK+uhIY3jOFcE7rHvsvKc4ziO4ziXFvfYt0tjInyq97o+b56neOe8OhO0zYFciVbZvouGOVWlLrs6BKoGb56rwWukYgU8dSTsnw/h7vRvHkJRPF66LniZ2Tf+rc1NvVHxPJPnvjCGxXkuJOXR055hHvhC8HI1aQ0HJ2JoHU0Jk6fzQfseiCF5bKzEpDLoPeQV4lSVTpcmmhvAsDwP9fCnz4E3WnKv8tdS9eGHGtYsRrc1N6L3rGVpaG2CVXFOW8SOyLJBoQRem5XnIRGBLIshft6U30VC5oFLmJ5PSvndyppdX6IJKJdsbo7jXF48eQ6AG3bHcRxnn+B17AE37NskGX8NACA7JyVPZGvK0VMt1xF0egBWtbRuah6seqgTwSOnoYPR2yey1RIqyLlSrlX8B8tbysy6J8I6duHIUEz+osFQqpb99Z+Djh0KY4xJglratvmqN6pe7+gxm6+WolVrcQ2c49rzpt2DevtVKSMDtq7Jj43ZA9T7K5dAmleg96StVwcbcU5Rbz7/3OQ8Gh8FpCQwtpGVZ8ZLp82z1ohKvQZMSAlcvo2siNbEhL1BiUbkEuziPFYz0MEQtdHch+S7egQWHcdxLilu2C8SbY7SU4etzEtIWxPPxjJwviEMEOqwRU41niufvDJjLV8l256SkhlG+aSbb4lheT5xumd+2bk10GC5dx7VitXOr4hRXmsCI9qQRYz9uDZSSaNqHEptu7a+YKxJmH7IGrjwoyGzPvtqSCos3HocOCyJZvoMKLFlCKVetbp1qSnHiiwblEuWTKhGvFAANDEu3l/ZKg3U8GpyXrkUZWl1XDo2BdTl3rPlnvGRZba8oONPjMbKhSiPWy7F0L43n3Ccy4yH4gF48pzjbCXLLnyM4zjOFYp77BdJpxQeXVG9UA1Vzy1aaVZFkroaE7k6dikLS0qmZ14Nx6vyHFor4A3RTVfPduy4eewtqQtftLIxOiZetoTi0+l1FMTjLByRBLLxEWBDrqHzGRroLVsDLHFvKRcF0GOKVXRHwrWKqv1+9mGgJuNpnfmCKLl1OqCmeMqyKy5RAOZZI+epN2WOEmqnUil3jNz78JCF3SXJDXOLdn29P11eaHfiOKyeeJbZs9Twf6cTPXptIEM1ufeBYauPl+fB33wI/EioyS9cIa12HedqxiNnbtgdx3GcfYSH4t2wXzQljdZqm1D1BteboAOSHKbJX2MDtlaua+fNRdNfV6KXWQZmezuccX0ZpOVzmXioxaLtF2+3MBnGpIESksOSGDaZS1bTKIJ64JTYd13jb0k5WLlu6/+aAAegcOLvw3GacNZqA2snw3DSrrVQy4m2qAes1Aai8E4UgVlYNuU58bqjYE5Ctrau0RAAWF7pHXds2ER/NrW0Tp7Z8pKNr6H2agVYkETA2Xkbp67PUH4/I7KezhloJCQ4aulc+nff9E5vjuNcUbhhvwiyc+/tDScDltCWN6LDZhCiYRyWzHcghtmjIpsa9o2cwdKw8doCWA3wiiStZZkZQU3wOh7GLxQLwNioXR8IRnyLtG0bWF+28fKf43VLntMlh+Yq+KHHeuZG1x01RTYZn7Wla5aBtC48y7VQVRldJe1aPbrOMX+e3p++TLQ7UV0uLkdMjodxy8X4XDRhjmcWQZPyUjCRk7vtRxTwaHjQXgTOyEvWUMN+B6vyO+vyE4/lOM6lxZPnAHjynLPfKG//XTWWuTmO4+xB3GO/CKiaCwerB1eWpK1yCajI98XgxXKxbCpt66KW1m2bF6zefGxgMmQh3xUtp9sEph8L39XzHRmx0jMtFTs5HccqPOst4fAv/krYduSYHR9V4HKes3rDmoCWtkH14N3G8H9rDRgR1Tgp/eJHT1mzGE1800jCkYNAWZ7RWq7crF8rXq8JgHS5QD3mYk6lT6+5uJyru5cowcYGqDHWcy/ZI8HbTg4MmW68euzFQgjzAxZ+r1UBbWCjUZmcsp3+/vjLXwvjTtq8Hce5vLhATcA9dsdxHMfZR7jHfjHkk8oEEjU4ziWZqcdJ1WHzziGealIMHd4AQFuipqKVXh/PrTPLOn2pBQzKNk0MK5StJap6r+J5IiFkX3lr77w7LZuHate3coltknhGUsaGQtkEddRTnZnfqo3e7sQOa7FETMPZGQPnZu04SAmclqrJWjwRxRaqUTBH57i+FNXg9D5poB4TBmPL1WolrsXHZMJbj9t5E3JfOp8kMW9cEh15cxPUyanQAebVJ4X4/LoL4XeVnlqF4zhXDv1pRFcjbtgvgrRUjg+OFyUbXJLMaGAcvCn/2Y9L05Z8P3apXeeNRZAYTSpIRr1egDOA5AryAkH1UXBXs+E1qSwFimMhTK1NV9Sg1qtAXQxeOyfpyrkENsBeLiiJ6nGxvj7//dSZ8LnWtDD6kI4v8yqXTOY1H77We5eMdqpUYlIeacb5qTOgUik0Y9GXlHWp5W+1balBlOVocMCaxei6uobumy2rS9eXq8kxW3aIte1pbDyj0PBgaDCzuh7D/novNDkWn1fxe0M/9u6dfwfHca4MiICC17F7KH7P0y/NejHQDvw1KJcufMwFiB3WtkOzdeFjLjSP1fULH+Q4jnOF4h77U4BX7wxfuqmFwNXzVQNbrvc0btFt8fi8IdbEO03SSiWRjDMztnpMUgRpgp6WoKXt+F0jByjqdbpbjX5rrbd+XREvlKQmP7abXZu1cLh64MxB4Q3oCYtvUXqL7VVbFlrX+XdaptSXgypyLyfO9P680TLvWcvYmi1raKOUS2bYtXb+kLTV1XayehwQ5qza8jr+YGNLQh/dcnOcv2oPaHSleNQz6B3nSqLgyXPusTuO4zjOfsI99qeClrFRAhbvmoZFo72c0yjXdWzxpjNkSNR7Vu8YNfPUVdxGr1Oq2hq0JrJRbtzMxk9lvIKuu0eRFwLOSutUFiGZwwdzmu9l+5S1/iiUo978yiJw6lTPNalSBqs3rlQr5pXr3NSDb9Rt7V7ppj1d1wAARw/bNRbCPOL6d7sTxWqiJn61bOI9OdGaeNx1R8O2fOmalt1pS9fmKkgT5KT1KhIyjXpNylOt+04LLFr7PB0S8LpzTaQfDq17i6/6ABzHuXwQfI0dcMP+pODmR8IXNZ6bayGZbX3eDLwar7Qdm7mQGN0kyyxJTUP3ajz5PJ3E8kZcXwjy0q8aKl9fRAEAVQZN2nZ4Mnee1MyfEaW6ybF4/ShnWxm08dXAazOacsmarujUikNB4Q2wbPEsC6HssWEztiui+La8ChqV8SRjHu0OUCyA55eswcvAIFCQdq6S2R6brxQK9gIwOtH73PqqEyLyoqF6AOAs/q6wILX+a80wbrViKoGbTVCjDiys2Jr/o/JyUyxYqF9eJpJ6CdncBqi+/RwDx3G2CYX/Ri7LpYleCuCdAAoA3sfMv9a3/7cAfJ/8WAdwgJlHZF8XwP2y73Fmftl25uKG/SLh9fkLH3TBQbbfHpQqO7DGuxPJc3kN9ycBzy9t3fhUEwGfyKg/FTTCkWdhZeu2b4Ebdce5uiGiAoB3AXgxgFMAPk9EdzHzV/QYZv653PE/A+DZuSE2mPlZOzUfN+wXgDufsB+6Ynhyteox4Uw98m7bPF9pFELnKR/j1rKVkqnXr150a8VC+3kvXZqzxIhAZdDmIsfHRjHFsiWOiV462h1goLfsLh/2j21b5TrZQ181w7ckHnh102rQY3nZhoXWVdNdKZdMVS4XpicNfQ+J95+v/9fjtFzv4JTNUeedJHGZgldn7Lyl8MLA6xIlkOQ/GhgHmuE4/ubjYV+jbhr7qktfrgKN4I1TOZzLeQ19XYbQMrrKBtITy3Ac5/JDoMsVin8egIeZ+REAIKIPAXg5gK88wfH/DMCbd2synjznOI7jON+aCSK6N/fn9X37jwA4mfv5lGzbAhEdB3AdgE/lNldl3M8S0Q9td7LusV8AKr00dHODtVxFUgTV1Gutx23xHG3N2paSrrRtyWTqgacbNp4m0elYWbolsQ6UgLlr+4Hgxfav1cs8iBOweNGx41y9ujV5jhLTj9eIwCNfDruIAG1Hq8lxK2thzRuwhDkAmJC/w31tXmlk0JT1VqUbW7FgCWw679Vle0YTst6tpXbFsiUTkmjSdzv2WtoS73xh2Tq+QYfXTnXzsQNdLGMbz3V504jDYNVEdqQDXdSYzzKw5hDIuMmhISTNvk5/juNcFnYxeW6OmZ+7Q2PdDuBOjv+hAwCOM/NpIroewKeI6H5m/ubFXsANu+M4jrM/oMtWx34awLHcz0dl2/m4HcAb8huY+bR8PkJEn0ZYf3fDvpskB17X83Mr/Vj8Xo7r0jnBGvWiSbuOLZpHr2vxWQbeCGuz0fvXfa2VrZ542gaavQln3Fy06MCKdnUTj70xaZ6nroVTkuskl1tj7y93U132qQPAcvDi9Z8K12s2nni0vLoGyJp2cmvI/4iyut3UkuJ03ISAtK8HfH3ASgGlE17Mzm+tAMtSZhYz8RmspWoyBm/kxHCizrv8DuaXLKM916tdRXDiGvvGuonb6Pq7RhLKxSjZy/PhWdHkGErHD4dpfPGWcPh3/Cocx7mq+DyAm4joOgSDfjuAf95/EBE9DcAogL/NbRsF0GTmTSKaAPDdAH5jO5Nxw34RVIs/AM7C8kirGwxIVcvdCkXLmNeQeVK0sLtSQG8tOWBh7HLdtklIntvruRKvVtzHauxVB31YEsq6mzGMHhPfVmdAoxLelqY16LbBc4+G72LEtcSNhgZMo11qymmgbhnwMi4ND1kDF0Fb2/LarNWBa7g7SewamkQ3MAaq9mb4q/4+t5uxyQwvrsSxYohcVeXKpXgc3XBN2DYq99lcAsQYxzK2NLVlhfgyMwmUpXTwwa/L+BW797z2PAA+PQMauaZn3tlX3ork6f8ajuNcWkIo/tJfl5lTIvppAJ9E+N/9/cz8IBG9BcC9zHyXHHo7gA+xiosEbgXw/xJRhrDA+Gv5bPqLwQ274ziO42wTZv4YgI/1bXtT38//53nO+xsA37aTc3HDfrGshSStqrZVFW97jhcxPBRCyaV18S71GMC8+CzbIjgTw+PtZi7Jrm3n9Xdf48z2a1laOVdaJglqvPyY7CtZaFrD7knRPHVNLiubp6/eLU1N2nX6S9qKBZCEw7MHvxiOV296chKoWivZcH8dEOReKjl9+v5lAn0utSHrcieJMZx2wVLGR+XgPdPwYLwGHbhW5isla5trVqq2aAI8McxezZX81WRJQIR4eD0X8o8le7k2ubIkgTGJhmSM7t/+H2G4528rouY4zlPEteK93M1xHMdx9hXusV8kNPSqnp+5+xcAgGFMokSyNjwY1o8pbW9VVeu0zCvvl5ktlmOinCahUXXYPFhNmFubNQ9dxXPkGCpWwOKN0o3Xynl1u6ZGDtYXTAa2Lp61aq9nGeigCMjUajbHdl9r1Cwzz1e8+bgmPzsLjElZmZavDZbNK18VudvWCli8a3QksW7+XJxP1I2PiWw5tTed78S4ldb1lfBhbh48LePJ/dLwkHnZ2gcAsPwGWUcnWbfHyKDlHGi0oFaN+vFUkGuXiyaH6zjOJcO14gNu2HcIKvwjAEC7+4nYopXEmHNr2Zq5qEGrNnoNOZBrHtMAOiHUT3kt9/5M+Y11S5DTffKSwO2mZdk3tMFJYvXx+jLRXLdQc7s3AY5nF4JuOgBoclxzI/YrV+PFq+sxaU0NX2zCUq3Yy0RsvrJkywqDB+T5lUzLfV0Mu2S2Z49Ng2rhPpMX/MNwzc1V4NFH5LvU65+bBY7InPT+Vubt3rRKQO9pbMheNjKrRY+18rqEckie98parJPnVQnnjw/ZMoiOtbZgYX/HcS4ZROSheHgo3nEcx3H2Fe6x7zClDDHszql4dZTzlPt02eP+PJwFZbUcVMiikl304geGc2mvcmIAACAASURBVAlnMoZ6nhrWBixMn1Tt+4YkfDVbVoamHntMxCtFr1m9dKzlSs9ydeGxHlzL1+IYlRjBiKRtIGn1PA9OrLtcLM+T1qjoMnAgRDyaA8HTr1eHwCOyXxvKpN3eBESdLxAS/FTjXsPvgxPAzCl7DgBw5DC4//ehEYekaWPo8262rFTu3Jkw7+VVUME9dse5HFyOcrcrDffYHcdxHGcf4R77DsMrM6CCiJiISMt5+6vnO77pvpynGNfkdc083YieY1Rky6nGxTVr9VSztFddTsethUQ2Xg5rz7y6bh6nTmcmlMIlN18T14q1CxqnKZCKN6rCLbWqKb7pPci6N5rr1qVNO9ANHTQRHxXYKddjNEHXzLW0jA6NgI4fBwDUC3Kf62ejGA+Jh49G3aIDc7m1dSCUs43ImrkkNSJtx3uP6/TTZ4ExeYb6XHSMIRMZ0twDPj1j6+mqQd9qb9Gsdxxn9yF4uRvghn3naa0gPXRLz6YiEguBa0ieMzPo/Q1fcolcuo1K1Xi8toNFp2VZ8YW+X+XGSi48L9c5ew6sDVakfpyGB02ataryuGpY2bLPxSjSxLip3Gmm/MbGEycC5trC6gsPuqktRei++misradxNcBiSCcPmczsvKjkUQIaCY1neEMy3xdWohxsrL8XCVjUazHzPcrwZpnVr0tyIG9sACfk5UDvXZ/HRisaeVWeo+FBU93TF4ByEXRTeBHJvhT0KZJnvQWO4+wy5FnxgIfiHcdxHGdf4R77DkMHbgJDQsjIlaflPXXAfgbMs9Z9gHn4Wc7zFa84epyUxES66MXPae13audqk5ROB3RO1OUOaZJbOXrIUb5YleXKub8eGk1YXw7hZ/SVtGkpW1+SII0es0S+3DIBaeMZWS7g9rol0kkyHB0RnfdyPT6j6KXr/QIWTt/YAEkUgVTPXpcBtL49f243taUGLRusVXO6+BKR0HksLAO6TZvGlEuxQU5U1qtWTI3Oy94c55LhdewB99gdx3EcZx/hHvtOUyijKC+Mqp8OZFsV4rqprUurl5v3dnVfIefN961jU1LMefZyriZ1zcwDZ0VMpRM8cJoaB4bEs9aEszyylhxLuoYatmY+E9rC8vyieaMLsrY9MWKRA02K08Q9SpBymFtR8wCSBLwavH6simb9gHV2i+vX4p2H59C7dk9JyfTu8y1aNcqgGvQtSTTsnrN7OR3K0nBgzPIE4vp4CRST5eRZ6XlDDWAwJB/GNf+l0xbNWJix+eravc7NcZxdJyTPXe5ZXH7csO803Taovx97oWhGXuvO801g+knbZkyU5tKW43llGljf2hI1opnqkuWOdscMje4rFqxxip53QMLW+TlIeJ4G6sCwhNa1HvzcAlhfFPQ+xShybRlFfanRua0v2EuMLhM8ftLC4QfCMoHW8lN10JYpWlJX39kAHv9m+K4Z6CODlvCmLVoXpef98BBwOPRNx5HDufuSML7W6efmqb+zaMRpPiQlwpYQwFmsYGD9/Syf3dIP3nGcS4OH4j0U7ziO4zj7il3z2ImoCuAzACpynTuZ+c19xxwH8H4AkwAWAPwYM5+S7X+C8OJRAvDbzPweOecTAKZkzL8C8AZm7usjehlZXwAPHwIAkOSiMWeWLKbqcVQwjzjrK3frpr117kAIRRf6ju+0QkIXrLyrp25bvFc6KE1Y1ppW2iaeLIoFS1LTOm/1MlsbpkV/7Y3x/iBNT2Kd98jglnmQKs+tnAOLVxxD67UhQGvxi+LppynkcYFWVnruk9MWqC51/eq5L0zbs5mQ8Pj4iLWI1QiCPAPe3ASdnbb5AiEKUcnV4gOSCCjPWdvearLdwoI9I428dFPTJtDP+kh8Hsnz3gbHcS4NrhUf2E2PfRPAi5j52wE8C8BLiei7+o55O4APMvMzAbwFgP4vOA3g+cz8LADfCeBfEpHGT18lY96G8ELwI7t4D47jOI6zp9g1j51D7ZSKhJfkD/cd9nQAPy/f7wHwETk3L4VWQe4FhJnFnUMRQPk8Y15WaOSfxxauusaeIAFrwpuq0eVbuWpSWZYrd9N96tVX6r37AaA2BObZ3nOlDIsKBXA3ty4OgNsdK+8alMSwRt3K23Qem00bUzu/6b71pq3naylXtbw1YqBvzcsr0cOPz6A8AMyeDPsnghdPo1PAonjUTfHmRWwGlIA1WqHtbE/PxHXsGHGoDwSvGrC1di3ha26E+wdA2qa2WLDohHZ8q1QsIiF/fXkmJARSIRdl0dK9uSWw5hDoZ5bGkkDHcS4dXu4W2NXkOQr9L78A4EYA72Lmz/Ud8mUArwDwTgA/DGCQiMaZeZ6IjgH4Mzn3F5n5TG7cTwJ4HoCPA7hzN+/hopAQckdsRglFCzOr9GsxZ9j7m45kqYXspWYdWQZuSsa5nre8ZEZWw+5ixJF2ATG2nM/M1hC5GuV2x14KdNyyhKXXFqzVqWSX8/IqsBTerWhcQvz1GmhUa9U1KS7X413nOP1YGOPgNUAjhMOpWJE5ztrLwJHre5/H2pxJxeoLRto1463Z660Nu672XNelhCNDdvycvBwsroH0OdRziYn6crImfda1wU2SAOfEYGvS33oTFBP75J1zYx106w3gE6fhOI5zqdnV5Dlm7ko4/SiA5xHRbX2H/AKAFxDR3wN4AYDTALpy7kkJ0d8I4DVEdDA37vcjrLNXALzofNcmotcT0b1EdO9O35fjXAg36o5zeSgkO/9nr3FJyt2YeYmI7gHwUgAP5LafQfDYQUQNAK9k5qW+c88Q0QMAvhc575yZW0T0XwC8HMDd57nmHQDukLEvabieSi8FAGT8qTAXAJ1uSLYqUHjkxW4KXgzhaBo7vnUQDTm3xFOdPRu8ZSCqq/Hs/FY9cw27b2xYKFuPqVZiO1FVVwMAkgSy5Pi/CPP+2q+GHfWaJaPlVew0IU000mlh2SIA6nWrB1wfAVZOhO/qCY+3TI1O1fSGj2xtaKNNYdIWsL7UO4aGzgG7zyTpTR4EbJkh7cZoBUspHOo1ezaV3HhSzsePi3GWqAVNjllSni5pXHvUGvU88rjNsd3bdtdxnN2HXCsewC567EQ0SUQj8r0G4MUAvtZ3zATFom+8ESFDHkR0VM4BEY0C+B4AXyeiBhFNyfYigH/SP6bjOI7jXM3spsc+BeADss6eAPgwM3+UiN4C4F5mvgvACwG8TTzqzwB4g5x7K4B3yHYC8HZmvl/C8XcRkSbU3QPgPbt4DzsCc4Y0C95nqZjraqYJWLI2q1V7RAVLxNLOZa129AK5ad52bJ1a6NMkb7XBG7JmLp/UqEc9+FjeBcRIQHbiHQBynvuJd5hnvS5JaVlmyXgi6sLpmnm1B6UsrRFEZqg8AD40FbYtyRhpO6dfL/eSJFbSlvUp8eVzEIaktG1p1db/1esuFoADB3vP0eS4xVmLDmiyXcaxLM263U0FNTnkFPg0GjFyEDRxTZh3Vzu6NYHl3haxnfunkTT6BIYcx7kkeLnb7mbF3wfg2efZ/qbc9ztxnuQ3Zr4bwDPPs30GwD/Y2ZnuHlG5rNvGgPYRb+dC4AduAgCTRj3zWPi5XgNGgvGhofCZnTi5JUGOOx2QtjbV+modu1o2g6QvAmtNC5FrSF57nwPAdGggE0Px1YbVjWv4utU2uVY1qO2OtUvV1q+HxCiX66DBcA9ck5eEfEWAjn/6NPioZhtW7ThlQGvspWnMZjsmB5LKyJarW1vfzp61OUoYPb7cENnLQSHXjKY+El5IEkmU0wYySWIvDDrv9WV7uZJWrSVNUNSXBsdxnEuIS8o6Th+xEmE7uFF3nEuOl7sF3LDvJlmuNauGsrVcq1QFClJzriVfUyHMi04LVJIEuZZonU8dAFIZT+ux05J5zTpubCRTBA1LY5ZmTp9e0eSvqjVfiWVjkrxGQ1NxFx8IHjkliZ0rn1wsAOc0NC2fmvTXSE17vSD3mWUAt3qPy9g8dA3P63JEu2nfBZocs2tpiVurDTRPhe9S4heTBNudrYmG33YrUJNIQPTwz4D1OR862ruv1ezRiA9zrPRGFiAJddeF32X2+G/J9cM1kxv/JRzH2R2I9mYW+07jj8BxHMdx9hHuse8meQ3x2Ia1bNvU69NEs7wGvKwVk67v5srBYmvURVM34288HL7oeu+xI+aZVnMCK0o+4azVqxpHh46Fz+o/Bad/Hr5rPkClAZyW8jUtJUuSeI0okKPtUjnXxY7kOuvz5pW3ct7u3Dn0UJdSu5U1yw2IEYF2LLfr6cam9zUmiW/fXI7H8KyUzHUk96G1YaV1s6J/lKYm4qO/P01yLJatZa4qCGZWtoj6iB2vkRPV5O9XDXQcZxcgD8XDDfvuErO721v3VepPrDxXOE9Gdakax4ttRDdWzIAqZ4Jx5LNzoO94RjheDdXcohlDNajFQs4YSuidNWP9E1tfSJJiDMWzys2m3WCEE4oytpgXIzq6CBruHReba/GlQNuqavIdjQ5bjbquUzfqZtD1vG7XXkSmJmVuMtfRg3atoYV4HunLgSbMNTeAqiwFDA31Psd8eD22xLXadNbncvZxe8ERRbuYtNiox5r5wj/8bTiO41wK3LA7O8MOlJjE8rLtMHrwwsdciPQ8L2JPlUb9wsc4jrOjhOS5yz2Ly48b9l2EBl4BAMjmPxAT5GJYGrCEMO7Tau+mlgxXzv2KNHFLPmj8OPjR+8MPGoLXGu0DYzZ+USIH9Y2QcAdYwlm1HJqnADFhL147KZrHHhPIVnpD+kDwrCckDK269EnuPK1Z3xAPvN0Bz8z1jtGoW/hcvfP8ckFfKJ6SBJgMyxQ0eW0Yf3XGwuZ9dew0OmBz0nHLJUBbxA7L/Mt1oNpX0qbnNVvAoOjjL4VlEJ6etaRGPS7tgg5OyNzDs+ze87MAgML3vROO4+weiYfiPXnOcRzHcfYT7rFfApLx14CbHwk/xHX3zFTd4oG5X0exb52dM/NCNTErbdtauXqN0nGNDt5kwjer4pWWSzlPWrzRdgdIpHNbVbTo89fuF2RZXTbvWRTrkGUWAZCSOZK3ZqoOW2c2FeBZNtU4OiZtW8ev25ocuCQtaesDlkuQ97rLlZ5HRKPHwKe/1nt/2gL24LjpvGuYvFgGViRyoJGGQwdMN17vXSIaaHfsXmTdncZzwkC6/t+xjnna9S67/xE4jrO7eCg+4Ib9UqFGIh8i7rZDUlrWF8otVLceD1hSmxq+1XMhBH52zgx8Pvt6VYyWGt21DWAkV7cOhBeCLItSrQDsxSFJcy8TuXVnqYuP7Uw1/N+o5wykhqLLUaKVT4oKXLUMui2IEqoqHTqt8GLDmTXFUcW6tVlL3lP51mbL1vWH5Lm014HJY+C//oyF4CVc39PmNd+m9ujh8P2UZMW3N8OfgWGATT0v3MuqnavJdkmypRaetGogy+I8suWcwp/jOM4u4ob9cnK+7Penytm5Cx9zIfJG/WLZiWQx3n5JGP/1Z7Y/j4EdSOLz8jbHufTQjuTx7nncsF8iqPYyAFJCBoCLZXQ19KwS6Sy/jiy1sHze2PXXVZfrwOFDYfxzYuDFc8/+5lMxy5xuCd4xD85Hb5zqwZgHb7hfTU2MdJL01uLr+FoXL2F/zC5Ywpuq1w0eCJ+dFviRR8N3CeHTYAOsJXAaEZg9bWFuNYoN1WgvWph+Rjz2lbXY5CZZkWY0i8s5b1zC4qKFT+0qWErwqClLCdWyRUk0kpGm8TnoM1I4SexZ6We+mU/UuO/a/y4yfuFY+F10/+i1KLzy9+A4jrNbuGF3HMdx9gW+xh5ww36J4TMPAgA2j9wCkqIEhniIFDzhYlKMymwsiVzUTc2jVc+QM9BAaHXK6kGeFK30YgHZw0ERLTkUvGdqTMb1eT6bS+Zqi4jLhHjZup7ehZWqtdfl2E7UXyddswbMe69K8pxo0PPabIwixFK8ycMgbaG6HNbdudMyFbh5UaBbEUW31iYwIePnkv66M8FT7k5/I9zyjROxzCwK5ai4TJbZd21ZmzEgzx5ajjg4as9+RZT9tPPb7IKVsakiYLsJnJPjZDmC15s5LX4pQ7xOdOfLJWRfeSsAIHn6v4bjODtL4rF4N+yXGu11rlnyrXIRRTXoarTYkq5IQuBZoQgMTiBhANovXOvOS9WYcMaa+HZ6GjQlRv9kOB4HRca1UrdEsmYrXCvLzIDJ+Nhsbm0uMzECAkLoXRXXxobC/sZYlFrlNcloP/k4aHQYPDsPiNwsDYyHPvOdFrgjWetqKLPUWtDqNZVqA8l3XBvGX51BCQDm5mM/eZRLYGbQzc8AnfxmOE7PzRh0cAL86CmwGnjN4J+aBOoSil8NlQR8egY8E154kqeFa6K1CT5xGnTjtfbys7QQrjt9DiSGXZvvIMuA0Yk4dwCgovzOum1kc/8hfD8XXsbc0DuOsxO4Yb+MtMpP7fEnfJ6NecGbJ0PlPEluTzXRq93Zuk3Xw88Dz85v3dhpbd2WpVu3KWIYe5jbOi7d/Iwnnsejp7Yer3K0+eNOz2zZFo+/8dqtx0+f23rgt3qm55EYdqPuONvHQ/EBN+yXCar/ELj10fCDtjCNuuxFS2STz6RrzUZiAxJKLMlOPfyJ68LPS0uhhyFg+vBALsEr1/hFtc03pN5d27ymKXg9eNRal47rbwRVJMze2tpznLviDW9K29TVNUuoU+PcbppHL546VYfjnLi/1K+1Eu9TlwTo0K3gQvDK45JAuwN+4EtyDxIJ0PD4/KLV32sS3+QYMByiGjH8n2WxkQ3dpuF2Ubu77qjNSZ9fvWrNajQEODpszWJE1z/+PrPUmsUsT8fxsxPvCENIRMdxHOdiccPuOI7j7A+83A2AG/bLiibS0bgIsqgnly9xi+vuKagmJWobYR2YygM5hTrxJPXnqWuA5eAV04qqpbWBTMLX6qXXq0CttvW6ADA2BmqLJ3sgrBW3x45gvhXW4A/revp6LiTeDCVlMZydZaBSrzAML52OHjglYR8vngzr1YCF+tXDThIL3UvEgVdngFkRvNHStvml2CUuRgmUasXU4nQNvDEYExJ5dT0eqmpxUXFuTcZcawJ1XQ/RRLwB0E23hu8FuyfNHYiRCZ1/ksQcCSxLhKRatlwGx3EuGg/FB1wr3nEcx3H2Ee4mXEaS638JAJA99psAANL173LdPDz1oimJHn08Lp+E1dfTnQYPgqNwinjMm5sWAVgRj3J9A/EFV2VpVYAmy6KnTiNH4tjDZekHv7Joc4yd0MRrLUjP9nbHVOn0GBWvAWzNv1g2mVado+rDLyzbnMqbdrzozUdve62JbDV4+0ldhHgGx+Q+m4AK2ciaOFXX47ZImkYhG4gYDg2K514uWaRDS/PKdRO5WQ8RB6bEMvr7ciX45IzlMGgWfdpF8rRfgeM428e7u7lhvyJIrv1FAACv3hk2bK6Zccs1ZGFNkNNtxfIWw2F13k0L7Ut4HNWG7S+H8DJlbFryipaxZWlMbuOVaTmtiLIatXwWu75YVMRQT0ntvJbS5e6FihUrc5OXj9XhUQyVbgjXmn0o7KsN2Xw0QU7L0jqtoDQHWOh+bBgJZJsafa25r1TAQ9KeVjXuqzWrN1djW69akp/Wp+vzqFaAxkTv/c48HufGs8Gw0/Ag0JAxcpoDQOg5z7pccC68OCQv//dwHGdvQ0QvBfBOAAUA72PmX+vb/1oAvwlA1uLwO8z8Ptn3GgD6dv+rzPyB7czFDbvjOI6zL7hca+xEVADwLgAvBnAKwOeJ6C5m/krfof+ZmX+679wxAG8G8FwE6Y0vyLmLFzsfN+xXEHxCkumuudWSqdQz7LSC+hyATDz3LqcoJeJ9ahKYtmptrVhJ1oaUrE3daF6wjMWV09YxTT1TTVrLMvPK2+LRtjvR248haMCiA9rYpi7zPwjw4yKoM6aqbWWQRhjEox0sj1j4WrTqNbEO134beFNEaBZDFzaembdEudiGtWjfq70NdrjTCR43AN4UJTzOLCKi5f21od7WsMh54iODtkSyOGfPQ9HWuc2Wqdzp9del/G96Ht1T4V4qP//HcBxnZ7lMWfHPA/AwMz8CAET0IQAvB9Bv2M/H9wO4m5kX5Ny7AbwUwB9e7GQ8ec5xHMdxtscRACdzP5+Sbf28kojuI6I7iejYUzz3SeMe+xVEctubAQDc+qhpxOvyN+e8Z/HSCYkl0Il3TgXxMjkDVvs82nJ9S6vY7oEbUJRyO37ki2FjLDcbsAOHD9l3TcrLi670KeBRWUrhACCZ7pljOEDFeORemku2X/rI663TyBHTb38o9Drn5XXQgAjNqE59axMsXjPV+kRj0i4gCX0xAY6zrd3aCkW7l3HJE9D1/VquvHBYIhQ5XX+clPsslWxtX8RuYh5DJwO3unAcZ+chAgq7kzw3QUT35n6+g5nveIpj/CmAP2TmTSL6XwF8AMCLdmyGOdywX4FQ9Z+Cs0/1bixu7d1e7LRjnTSVxQir4a40gHExmvn2o2qU5SVhEwmKRQnPa1/2ZggVU2MS6WAInzfTUHM91C0ColEfleeoamHzvux8bKzEDHmsSN32SGqtYeNNJ3aPbQlji3oc50PmGibvZBb6lpA8M8ekuS3xuGrZsv71xSWvd1+WJjClqhlqfdGoDcR98TmrTj8AVh34Z1qGf7y6zDspyDLATbMonwnLCd3nhJfywvf/LhzHuaKZY+bnfov9pwEcy/18FJYkBwBg5rwG9vsA/Ebu3Bf2nfvpi50o4KF4x3EcZx+R0M7/eRJ8HsBNRHQdhTadtwO4K38AEU3lfnwZgK/K908CeAkRjRLRKICXyLaLxj32KxSeEx10acuK2gg2s+BJVvR9jDOQthvtUy6jyiBQ6k1GQ6UBlr+kmog3kKXxWuqpY1j0zesj2OgGb7hcEG90Y8US2YoSCq8OWqRAw9hS0w3OgKOHw3fVgm8tA6KeFxPmOi27B/XE1fuePgccknp6bdqysmaKc5KYhmYLGBMdfUmUi6V29aq1pdX7XFgGJiSkXrGEPV45bfsBQMrkMDlkZXraQjdtW5Qi16gmdt4b6GuOsz4fr0nyP0b3v/0CCt/9djiOszdh5pSIfhrBIBcAvJ+ZHySitwC4l5nvAvC/E9HLAKQAFgC8Vs5dIKK3IrwcAMBbNJHuYnHD7jiO4+wLLqekLDN/DMDH+ra9Kff9jQDe+ATnvh/A+3dqLm7Yr1CSA68DAGRn3gUAoHId5TVZohmSiA4lQFXWx5O+VZUktWQ79S7bTZB6lyq0wpkJ2AjavQ1pG4NaTtdpx2vG7m7dTtzG84+G76vi5era9eQh88rTjTguFiRB7kRYb0axADooc5JSMe52ZT6VLa1i6fgR8OZmz7XoyEFToev3+tsdYGk6XgtA8OKHxIvX5LzVmS0tV3la8hjSrkUClCwDBiU34dyZeC3WksGx9Z7xMX3WIgDaNU5zEBzH2Tb9/xVejbhhv8JJDr8BAMAbd1niVj4BTlTgqPiScFznE2FfrqELp2IAF6ZNQvXI0fA5exYYV9lYCftroholWxXtynVkGraeDSF8nlsAnw5Gk2pi0EYlJC7tWwFYK9WELJEt3+hFm8SopKvWoteqwIC8bKyExi+83ox15lSTSoCZOWBkCD3oC0HajUp1MZw/NBSfJZ84EU+J96DXn5GXkCSxc/XloNUB1uVlRuvkV9cBrX3XQcu5RjgqbcshU55PziD90I+HYW//IBzHcbaDG3bHcRxnX0BEu1Xutqdww75H4OmvgiauCz9oaLtUteYibVnaydeKJxqGFq95ZR08Ly1fddzVNdCYJHiJ95+Wg8da7LTNY5fEsJVsDSRh7sa6eNZrTWuUop6s1tAXc2FmjZE1WzEcTeqxN1vIHg4aDdlyiDAUDkst/EYLJCH+mCg3twg6FpYkNGQfw+7571pH3k1BZdmmdf1LSxY5kGgCDdTNyz8cavdJ551lVtuvv4NiwSIR0iqWiABtDauhe1XmS7uh/SsQr5MttFC4YRKO4zg7gRt2x3EcZ99wmSRlryjcsO8Rkut/Cdn0uwEANHQwbMy3B+3Xlk9z3raumef104s5FbY1Kf86HDzOYju3Lt4njDPULYJlbT16nq22Jbqpp6rr5SdnQbc9o/dm2s2oX5+fD1XCPRQmpOPa5FjPWABAx0PpHLc7VjYm8+C1pnVu0zVtfQaVuiX06TMaHgIyWR9Xr7xeNS9bu9jVW/E+41y0tK2TS+rLd4gbGek9TqMn9QFLGBRhncK3HduSHOg4zlPncmbFX0m4Yd9LqJHNh+L7+7argc/to1rI2ubqvCWrqSFJEktW+5Ko3eVrwPV4NZ7zS2a8Vco1XQQ0RK7rWxqWvuGYGbe+bHMAdt7EOEhC5Np0BSNyndamhdalTp4OjlsSmob969Wt96dUinb9GEYvWwLeuBjidmovAOkZu76Or5UG+nJQLJiLoC86GW990cq9LOmyBeu4C8txeaDzez8abvO1fwDHcZyLwQ274ziOs2/wULwb9j1FMvkTPT/z8ofMi9dPTZ4rlgFUe/bR1M1W36011LmiT01MI/VYD4yBT8+E7+qxL67FMH48d3x0i7et4XE6dqtNWFrG8vJ0bF7Dy6JL3+4AE+Myz5y6HBC8av3Xqh7wUANYknMlQY43WuZtDw31XJNKNbDOVz32lUXz7M+X5KfevzZ8OZ+OfLtjx7dl3EYtht61RJHV0680gBtlTiNB4Y5n5mPkILku1NV3//R1KPzge+E4jvNUccPuOI7j7AvCGru77G7Y9zqFPk9dPVpKkJbCviLJrznLekvOBJYEMCpJwpkmnhXLcRvLujsNZ+a9Qy9FtgYu43JZPOfmvHmvoptO9VHzYDXJbmYOUO/9oAjlyDo9imXToNf7K1UtuW1ZFPnWm1a+NirXVBU9zsxTl+5qqJbj+nzMGzhydGu+gtJuAq2cyA4AVCp2nCT9odIANSZ7xlDFP+5ugkieqXTTo7RryXaanVSN5gAAIABJREFUZDd3Dtl90sZXnotS+N7/G47jnIcn37RlX+OGfQ9Dw7eDV+8EgNiYRQ1KliQoUF/oOUtN/lQbqOSMhhp4bIpxXFzOtTXNGf26NDiRsD5/82RM/oqZ7BraXl/KjaG17mVrJSsyspzOgEYlfF63Nql6vNXnZ7ZPDLpKvgIAS7Z9rHtXQ1mu5xT77GUi9nLXF54kATblpafZa1BRLFgCXiqfg3Wbp764FCrh5SCvM6CNc2ZOgXWMvNytKghqS9xhmUM3BeWPA9D9k/85VgS4kXccpx837I6zG6ix3w76QuY4zpPCy90Cbtj3ODT4PwAAssXfDxtyBqUr4e74S6Zcd4QBbVNK0RPkmXkZUzzmcimEyAGLb2VsSmsa9i4WYqIby3GkWvHFQvT2eTUk4tHY8VwteYgwULtjXr6G6dXD5iwkugHm5abzMXmOZ0RNb3zI9NpjEp/MtV41rXjRgqfBhiXPqRe9PJ/z3vv+h2h3gIbcl7bCLRRBiUQz9Nknxa2eujbiabUtqjCodfJVa2mb5XQJdLyKzE3LF48cRPf+x+A4jnM+3LA7juM4+4bEk+fcsO8XktFX9/zc6f45iuqF5pPBtFxLRV2arVAmBmwVdSkWgocOmKdcLgFLK2HYVfE8D46awIuuxU8cCftGj4Fnvh6+jxyxsXVO6rlXy5aEFkPQuhadATVZ19fSvYFx8NqD4d6vl3HHhqOYTPfeb8hYYYxkrGZldDqFbtfK/vq17vPPoyGJdQPVKPajZXQ9Cn+5T16Tdf9HHw6f2pK2UTO1Om3fOjBiz6GlGvu5hEH14jekM9+BMSQHQiSl+0evBQAUXvl7cBzHAdyw71uKSIB1CaNHA5HZ9/a8Hdzff1zlYZutKOEaDd7ahrVklSQ6mhwDJg71XCuq3SVJTAzjpoTMywPgthipXIgaiRi8QQ3jS8Z/oQyUZY6SDMfcNWU6NcBrzfiSkgzn1PP0vjT7XzP8S6XQEjZ/f3lZWHmZoWF5cRgY2/pC0k0tsU8MMGfrYe4bKzZux+4tLg/oy0FStPHy46ft8CI2J7+rA/JiUmmAbrgmXPLvwwtM+723g5u9L2bF60Myn9fDO1cLvsYe2LWW9ERUJaK/I6IvE9GDRPRvznPMcSL6SyK6j4g+TURHc9u/SERfknN/UrbXiejPiOhrsv3Xdmv+zlVMfQcS3zZWtj9Gp3XhYy6AG3XnaiMh2vE/e43d9Ng3AbyImdcoFO7+NRF9nJk/mzvm7QA+yMwfIKIXAXgbgFcDmAbwfGbeJKIGgAeI6C4ASwDezsz3EFEZwF8S0T9m5o/v4n3sSajwj8Drfxx+iCVfZZAqvh3QdqXrIPVq+0vVMjYjpx5lxlHVjfJepnqtzaA7z/rzRtm8cvVQYWVd0PKuzSYwJ5r1qlUv3itVBsFd8UZbYjDTNjAXIgCxbWu7Y6V1qoS3KMlrrY4p6sXyu6JdS5cQVtZCaBwA1aWePmr0t3Mhc5lHNwWvTMu5sm1kzBL/tJxOIyW1IdDNB2XeohW/eMaejbZ35QxYXu99Hvp7TNvx95I855bwmSQWbdCkvyPXI/va8bDpab8Cx3GuDnbNsDMzA5D/0VGSP9x32NMB/Lx8vwfAR+TcXFNxVCCRBWZuynFg5jYRfRHA0d2Yv+M4jrO3IPLkOWCX19iJqADgCwBuBPAuZv5c3yFfBvAKAO8E8MMABolonJnniegYgD+Tc3+Rmc/0jT0C4AflXOc80MArAAC8cZdsSMCpeIntXJhX16q1zEs8dj55Nnp/dERaxTYaJqaiOujNxaj9jrOyrn8gl7BX1tI6FbmpW6KceuWTN4BTSXhTD1lLypKiKbep11pKTFAnp6IXvXHtnNaR8as5cZkoMtO173FtvWYJbKpap1GOlVVT+tO18M0189TTXNe9fu1+JcsACseFfx4Ap9347GlQvPnl05awqBGU1KIscb5Hg0dOlUFwa7n3uM21OG73T18HwEPzjnM1sKuGnZm7AJ4lRvhPiOg2Zn4gd8gvAPgdInotgM8AOA2gK+eeBPBMIjoM4CNEdCczzwAAERUB/CGAf8fMj5zv2kT0egCv36Vb21NQ7WUAAG5/zAxwNJ5izNdWt9Z0FwugioaBtdHJJtAK9eixqYoatPGpkJkOWFj90IGta8XFshlGMaLcXgfGpsBfvR80IGHsKUlao8ReBHTeTWsfy2oAz5yLc+3OhDEKN0g2er71q8ybN9ugaDQ1TJ8C2ACKRTAkxK5h9IU5C4ur/O6qGU8cCsEjlbHlTq7nvL4QbK6BNZxfyFUaaCWAPqtiFRidCiH/6bNhm/5eRgatLW512K6l11BFvq8/Goa8/xxK3309HGf/szfXxHeaS5IVz8xLRHQPgJcCeCC3/QyCxw5ZS38lMy/1nXuGiB4A8L0A7pTNdwB4iJn/n29xzTvkOBBR/xKAk2dt9cLHXIjxqW0PwV+9f/vzSHYgH7S4/X8WPUb9YmltPwGvc/+57c/DcfYIBCChXcsJ3zPsmmEnokkAHTHqNQAvBvDrfcdMAFhg5gzAGwG8X7YfBTDPzBtENArgewD8luz7VQDDAP6X3Zr7foXKP4DszLvCD1obfXbBPEFJOIu13ZWKJc/F8HUaFed4WozGyBBIa70VHStJYng5Nm3JUmBT28CeDJ+PnQIWRN99JSSNkTaBqQ0DSV9N9/yi1dgL3GWgpXXp5d751GuWICf3QoVcnf5Ibv4a5l4Ww5rJvFbXQFqPrhQLsc5dvWdQklOv682wjxr5yBn/xoSVyq3kogSqRqdleqqlPzAILAZlvdgjoFQLJYAw1b30sSVU/9V/geM4Vxe7+WozBeAeIroPwOcB3M3MHyWitxDRy+SYFwL4OhF9A8BBAP+XbL8VwOeI6MsA/itCJvz9YvB/GSHpTsvh3MA7juM4ALzcDdjdrPj7ADz7PNvflPt+Jyy8nj/mbgDPPM/2UwjRFuciSQ6/AQCQnQo5h9ztWrtWXT8W3XfUq70a8QAwOmker3aIm18ETklu4yHxaEdEA742aqVc6m1vNqOnDvEusdY0L1+T96ZzYeRRCfVrYliSAJkI6ahq3PBATJqj/nB6tWy5AANSalcu2X3pZ2sTvCoRAz1OEwhrNVuLl0eF+kBs5cqJqM1VGqCiaNYviwdeFZGeQtlK4aQMkEaOgFnmq2vspaq1uz2S6zynz0BzA6Renk+fiNGV7KFwzdILng7Hca4+XHnuKkPbvGpCWHfqVgBAYeah3iYxQOy7DgCQHulUHY6Z9TwvjVnaHfDsAmjqgGWyi4FingepQdd99RFAM7gbUqs9S8Hwtju5Puzy13NlDahK6oUmmTXq1jZ2UULmxULYXq1Ylrm+tKSptahVedp2Ggx+/l6r5RDyXtuwF518Fr0mGI5aE5iYFa8vQcUyuNsOyWxi0OMLSdq257AqdfidDRO00WeVb7Xb3uydx8AgMKQKgrqksYzs/pBHmi2HZ1965hZNKMfZ9+xFD3unccPuBKO+TWjqwPYn0q9VfzGoMd4OazuQ+FYoX/iYC6FG3nGcJwXt0dD5TuOG/Sqi+/GfBH/1CwAAuvU5AICkXLXkNjUkA8E75+RRSySTsDF329GbpFtvssElHI05CZ/nFOBYPFPUJUGtNmThaIHGR8Gb4pmu9CmujQ2H2m3A6tPrtRAGhy0JBHUKiTpoolz+GlIeFz395dWgc58nY/O84z2I1z08nvOoc7Xi2r42y9XuN2RJQkvl2GroY/3/qDz32TM23yFRu+u0tjwjvV9wBqxKxEP17EeHkcizyRZ24MXEcZw9ixt2x3EcZ9+Q7GpO+N7ADftVQHbvL8uXzNaUxYNMssz0yVXTXT3FxhiQSkKYrr+XqkCl968NVQbBq0G0JnrbDVnHrg8AZ4MXzydOy/i5kLuupwPmfd5wLPysa+GFonm+Sm0gd54k23W7IBWf0Va0TfFey6WQ/AZYEl25ZOvuuiafJCayI0l/UQSmvQ6s6lq4trMt2L3qfXU6VoOuyXC556ca8dFzHx4BSZRE4c1VW2eXe9VjeHkaPD3bc+80Phq77SVj4bP93ttRft2H4DjO1YUbdsdxHGdfEARqfI3dDftVAK8HD5xGh4CD0l9d13wB8y771oOpPhLKs/LbygMmrJJK5vvGonmkh2V8XYturpumu65FtzvgjvV8BwCMDZv4y6j0He/mksea4llrmRdg68xLItJSqcSIRPynLVnxvLkJ3pB554Vt+pXqEsp1wzOtegDB+9Zzy7L+X6kDmXS0k+x8arWB4lrvfPW86obJ6A5JwmGlYcl2GjkAwLpmL78XFaBBoQiamuydf30ApB3fpFwxfaxHxNFxnKsEN+xXAYUX/BYAIPvGv43GijNRM9tcM8OVD7cDIdGrIIZxQ9TXstTCy/qZFLc0dYm13fNLoJoYpoYY+KUVkIbz01zLVWVdDJLqwlfqMWmOF8M8aKAeX1gUmjqQa6sqRlzL2PJa8bnEulir3paEuvUNeymoyLPSFwzObAkgXxqoSn3qKZRLwJgozOlzWdZ7KlpCYlVeuOqjZqCjjnwZVJMlADXoK+fsuajSn5bRdVNrziMJgXRyGe3ffRXKP/VhOM7VgnvsbtgdZ1/jRt25uiDXiocb9quK5OZ/hezEOwCENqmRWMLV57EXctrl06fj4TExTT3V4cEtqnHRU25ugFUNTsvNjhyMeuaxRKy1GbdFJbl8O1ktfZOwO681o+dNAyr4kis903mod94pxegAFWRfvWr7xYumSjl673EpQEPynFl0Q3Xvu+1cOFyeW6MOGpL2qwuiha/3m5Al8Yk3z90OIBGRSKEYvXcqheO5bPr70bNXj50SK8ET9b/i84rI/u6NYZsuc4iaX/JdPW0bHMfZR7hhdxzHcfYFnjwXcMN+lZEc/xcAgGz+AwCkhErXymuypiz/LihtW4lVOWjB8+q6icQIPDMHmrhFxhBd+HLwXqndMc87etFVkEjUxvXmybGtynOxR/q6fddytuWmCckIVC7ZNdR71sS6UgmaMhdL3NbN648a8+VhKwlcEWEd9Y6zDEglEqGeMmdAta/cLeOYk9APDdSBcVl/z/de11JDmS+mjsSEOu7KuHl52nx+AwCsrdlFYsJeBl4VPfq+rnTdT/4UCt//u+edo+M4exs37Fcp/I0Hw5cbb4lJamomSUPQhTJQkXDw9d8eti2etEQwTWhbXo1GJ9Z864UOjAEDou62Ohc+11YttD4oxmo1Z5jUQKrRbXcsW3xcau4TAi9IzXwuyz1WAAxJOF9C/TwzZ8lz+kJQr8bEPmh4Pu3a3PRlIt+YRTXdm2u9c8x/T9OoA48BaemqWeyVnORtvgpBDbS+VHRTIMkl7QGANopZnrWXKzXiCdlz0KWBahlUHQOGGqDRoA0Qn9TMHBxn30HusQNu2B1nf5MXAHKcfY6H4gNu2K9SCs//DQAIyXSia64heBaPr501Ue2ItyheKw2Mg9WDLIeSMioWgJX5cK7Wu6vnnhQtqWtQwsHz08CceP3qWderti16vrnwu26TsD7Vq9bxTalWQJrEt9SrKIeRoahCx8vi1euxQIgsKKKep0mCsdb+UK7RTTXX5CV2hhNvXJPjAPPKE4kudFObkyYOUmoJjJOiupe2TDugEu5Zu+qhWABGRnrHyFLz4rWj3VABNHIkfJex+IFvyHw8c9hx9itu2B3HcZx9gpe7AW7Yr3o0mQ4Asul3h88DoRSuQEVkIiSTlHL9v1UlrSb/gJobVqqmXvGkeJvDU7nkMxGBaS6ZR63a8glZwlssmct1KdMOa6rzrt48YJ5ya9POlXV6Zlt/J01aE0+dajXg0JSMl0+Gk5wDvUY1J5ST9AngZJmt3ef718vaelwfz3eM0391nIuGqLhMUe6lUIoKf7wmuvD6O6gNbfXiOQNKcv3cf2y8HiIp2sFPdfiTp/0KHMfZn7hhdyLJ1P/W8zMv/SdgMISfWWquCQAWQ+IVP3oqHFgsmMEblaz4Yk6KVr9ruLlUtbVfNdStdk4uNicbGycn42uYe2m117gD4cVAjawab61rb21aGF9C6zw9C9IGLoPDNl9tj6rhf1GgQ6f1/7P35nG2XWWd9/c559SpU3PdOTcjYZIEhIvGAG0rGMA3an8gDI1IC0EZ1KZ9ebFBiHRLG+UlKJqmkVaigAG0MR0NpJFBIEG6lSlASMKUebhD7lxznTp1zn76j7XW3qfqTnXvrXOr6tTv+/mcz9577bXXXvvcW+fZz7OeoRCaAyNFW5pbfHQa9SNj4Aei6bw9TW6KhW/WC+e5+F357Hi4V9Ysxkjf4+QBPL2I5DkHqsUYifjvRMnwuJQigS66nRJaY5dgF2K1kjVP3OdElPQjJ9YPcp4LSLCLI8jub8tKlheLactlHoWFT0fNd6ZJaXvUYKNZPJmKaTWhuiijXe8g1GK4WCmZ3+tFmFva5pnn2v5Qo8bs0zO56d7a/5CTJp0Tw9M2bM6d+HxXKjE7hd8XMsNZSsS3YUvhkLbYwaynVpxLpW1bzVDeFgqNuVwtvrcUHpeOW82FRWggZJmbTwV1Yvz73FQRhhgdEfNnL5UK7b3VliUvvQgkbb7ak38f/oMfIIToHGZ2OfBegsnxL939mkXnfwt4LdAE9gO/6u4PxXMt4M7Y9WF3f8HpzEWCXQghRJewMs5zZlYG3g88H9gJfMPMbnb377V1+zZwibvPmNlvAH8I/GI8N+vuO5ZrPhLs4ghKj30rANnO92IxuYylJC3lSr4eXbr4sUCsuJa07H3Bic7TH1f/KJb2e9tynafQt6TJ2gRUU+a2VK40rnHXBmEu5Z4Pzna2YSRfk/eDIezN+tsSyKT5pDX3+Tociklj0tr81o1F/vqkRY8fzLPh5eFuj7kwbEfOadOsw1jWO5Rr6rmT2+xE4RSYSGF9kIfd5c8JRQa+tK4/OJhr3nmO+Pb1+eTAaLHNSpCVimcFGBgpKsTF8af+v+eF4f/rFxBCLBuXAve6+/0AZvZx4IVALtjd/da2/l8FfrlTk5FgF8ekdO4byXa/HyBPLUv/KLYtpI/10n3hXKV8ZPnVueitXW3gczGta4pnz7LCqzt6bTM/D6PBczsX9jMxTn1upq0tlTztLYrQtKdLTd72iW1xzPl6LkhTWdPwPLGk7N44j5lZ6A8OdfbEJ4ftUMgaVy9lTGRBYPeNhu9jbG4vjVaY02NLUQCntLrt80mCfvs5ebpdxlIGvwZsPyvsJ+GdXoKajeIFoNVW8MXbXgoAqw7gjUUvE40ZvDED1X7swnPD1J4fz0mwiy7EVi7z3DnAI23HO4FnHKf/a4DPtB3XzOw2gpn+Gnf/xOlMRoJdiNVKWis/Har9J+4jRBfRIcG+OQrexHXuft2pDGRmvwxcAjy7rfkCd99lZo8FbjGzO939vlOdrAS7OC6ls98AgE/eGBo8K8qJDgZN1j1bmPe8ndkJrH9DPBW1+Tbnr7y8aWMmd/7KtflUGGVqEgajyTzFrGdZm3Nd/G/cbBSm7P54LmrPVh3AB6Ip/mAoResHx7CUg/78mPFtvl5ka8vDzMKz1eamuH82XPvE0RD/Xu2r0fI473IQxGM9GY2RcO3WjTFHe7JMlIpyrPmzVHvy788GgsneZ8eL50rfQzKxD27O4919PD5Ls3Hkd1+uFOOeG4v0RAtF84YrqbzseoQQS+KAu19ynPO7gPPajs+NbQsws+cBbwee7e55NS133xW395vZl4CnA6cs2JWiRwghRNdQstKyf5bAN4AnmNmFZlYFXg7c3N7BzJ4OfAB4gbvva2vfYGa9cX8z8JO0rc2fCtLYxZKwoZcC4I1P5w5qyYGMcgWrRuewlGAlrfc2ZvLsaNYTk8FkTXwmXpu0zEo1DyHzpP2n9eZKBXbuXjAfdy+Sz6SMdYODuXNdPu9KW972ZNpuD6sbiFp5tVjTzuceM79ZOtc7yGYPmnplPoxVPvxIXjktrYFPMUlfJVgM9vSEMWYHw3M+tv8c/NBDoX9Pm6l9sbYNC6vKtW/HH8Xb1+AhWEGSht8edleP/1bJXyGVsR0ZIPve74dzMdFQ+Rc+cOQchBAnxN2bZvYfgM8Rwt0+5O7fNbOrgdvc/Wbgj4BB4H/GEN0U1nYR8AEzywjK9jWLvOlPGgl2cXJUaoUpeaYtXeliZ64Ux27lXCDlwnx8f2EqbxdayaP9cBTieT32Vp5JLneAq/YUjnQp3WylClk0W6eY7pTGtrmo1jsEr/r5+YX9Dx4G4jy3bll4zjM29Ialg7H5MNfBrY+jwsI4/dnJPThhnsmxbnI+vLTc59/nsTaYj5fPO5r7k6Mh5QqUB8PLTqrD3mrzgF8k7G1wSxEDP3+gbYxK+F7nFpZ5tQ0jMByXKZ5wwZHfjRBrEMNWLEGNu38a+PSitt9t23/eMa77F+BHl3MuMsULsVppzJy4z4lIL0tCiHWDNHZxUljpMnz84+EgxVI3ZvBWDD1L5vak1ZerhUk5Capqb5E5LZ1rNgqtMpUfbY8nj05x1hc11WarreBL6t9mhm8v6gKYlSE5+6UStJUK1NpM9QC13hCXD1gcb8LDvKfnxzmrP8S0zzRDn7nWNOVo+p5ohBj+2eYce6Ppe6oRc7RHLSLry5gaDRryYNK60/wAn4xLb1lWOP7Fc1Sjw1y5gpWik2D7+l8zfpfpuy1XiyWGWJo3D5mrT0HMUSDPedFNKFe8BLsQQoguQbniAxLs4qSxkZcDkB2M4VI9NWgtWsNOWqO1hbYlDR/C2i/gj/4wHFdrxZr6SEzwkkLXxieLLHOT0/k5q6WscWmtulLklY+V09zDmNY7VGi37Y5nydFsMq6rT0wVznXx/sOV0Xzr+0MEytmbgua+e/YB9k8/Gm5fCnOcmZ/LNfV/2RM098GecO+h6gQPTwbfhB/fGkLQzqtdWDjUpYpv4wehlrLyFVn8ACyFv7XjbUl/qm1V76I2nn9XcZ3eobCW1MN42devonTpu44cWwixppBgF6dMadOVAGT7P5i35Vnm2gV7eWFJUjwrHMFGYsa1uSkYiaVNk7CNfeycbYWjXMoyN962dpxM8s0WROGaO5UlM3arWTimtXuSJ+GWXghKJWygH5+fL1LFRqFrtZE8xv1gI5jMp5sTjPYGk/ZgT4jX39YfBPIDE/fwvPPDM99xIAjzuw83OTAbTPu18v0A7O8/wBM2PJl2Bsttnu3JZJ/m3WwUOQHak9gsTmiTrrMSPrG3eOY0xoPhuco/+R6E6AqMFckVv9rQNyDEInz+KB70J8kDE/ec/kTaLRynin7khFh3SGMXp01py2to/e/fAoq87Z4c5XpqRZx3asuyIlY8awvhmorhWr0xI1syzVfKhVaeNNmR4bY49+QslhWm5+TEl86VKpDyPKWCMocmCjN+NLv7+GSRSz4WqslN3JN7IWr9m2Lmt021HyGLud9LSWOer1MeuQiAe8e/D8DFG4M2P1Id50A9PNdM7N/MMh6aCEsSyZz/pOGLi2x10QEwzxuQZUeWaG0r/Zpn85ubLCwSE9HCMRqfbe9emFoGr3shVhUrF+62mpBgF0II0RUYFNUk1zES7GJZKP/UnwDQuvWNANhAXM8+7/zCpDwfS7pO7IV9MYnK5riuXp8rKqBVoiaZNPb+WpFdrh5Lnvb0FE5w0/FelfKCdeUFzNeL/OopY12lDI2kDUdtd2QItgaN14YWVZtrNvJxfT61zVFKFom4Jj9TrXBg5gEARqrBGS5p5wM9PTw4EbTtSlzvrpRKjPSG7+Fg/VB8vloevuYzbVYNwCq9IT8/5Gvm1jsEfTEnf7KG1KfyBDx+MGr7j+yJ824p05wQXYoEu1hWyj/zXgBaX/ltAGzyMF6OtQySMKrPFs5qUXj7rsK5y4aiZ3iqYd7u7Z5i2/ceKGqpp2IqlWoo9Vqu4NFkb8mM3Zwr4rwTo0NFJrtklj4rlDe14e15t+R4ZpsuLOqxt6XMzYu0xHv1943y2KEfZS6r0zsVvOJ7h8JLyN2Hb2ewGp7l7IEgiJ++5SeL78/Cd+WlEmx9AjY3UzjvpdK5PbU83e0Ch7lkno9pZKn2QxVoNcjuC8/Q8+q/RohupiTXMX0DYhVRWob/juXTf1dtF+qnylxWP3GnE81jbhnWwFvLUPpVCLGmkMYuOkL5WX8IQHbb2/Hv3guA/cTTwslSCZ8OQsuSub3eKPLBjy6KT+8fKjTTVMwEinjzmPOcrJkL9jzMLZmvyz1FVrfUv9WELN6/emQmtxSzXhS9GcM2Py7OI5VhLRVhdMmZ7/Aj9KaXg+EQzufTwTHwmWddwO37Hwbg8SNPCn0OPQKxvOvZ1RBOd6C+i/7KCAB9yUowtT/07x0snOJSXHpzLncYbF9C8D3hu88OzSJE92NaY0eCXQghRJdgimMHJNhFhyld8s5837Nbwnb3nVhf0C59b3SiG+zHtsU15L64tl6LudLLPfh4dPpKWnx9LqxDA5Zyxff0FHnPS4v+a1upyJfeXg7VZoprAQ7uwaejA1uyCMRSpwCMBI06D+HLskKTTjTazPBp3T1q3/XWTO40lyrAWf8GZpphnb7fgqPhpto5WMwIl8fVT6dc+9PFdxSz0TE7hqe1/vQdTB0gu/3ueI8ehBDrAwl2ccaw0mUAZHv+DAZjnPl0jDvvqwWv+M2jbSlo28zjae1868bYtHlhnDsUQs7b4ryTl/x8/ajrzTYSTOZejzH04xOFQB+N450V51quFGOUwkvHWDbGaH/0Rk9laWuDQdiXK1icx6Zokt81/SCPGQ7FaPorcUlgdiZ/5gdnQ2KbqUYQ0k8un1u8zLRvU2a96FDnjRn8nrjkMRSF/sYRSs/8UZqf/gbVf3/DEc8uRPdhmFzH9A2IVUQKfTsdFtWFXzGWwYnvyeVzT3uM5qe/cdpjCCHWFtLYxRnHRrbnZuNcu0xaNxQ52mNIl/VZKW03AAAgAElEQVT0Febl5KDWahYabCmGuzVmCmeyOEbKQeWt+aLQSyx/ytQUnDMS2+L4288vHPSm4hzPjg5zAxvJosAeb4QlhL0zDzM8+mOhXyrkMjZWLDFsiOOfFe598bZL2DMTQ9qiKX6sJ+PgdGibbQ/Ja89p374d2lBko0uWhp5aXtI2L5RzeBwbWoa0tEKsIbTGLo1dCCGE6CqksYszjvVfUVSES2VKDx8IpVuhLZFNdB6bmyqy16VzmUMtrn2nbHT1uZDMpg3P88hXCie4rVFjH92IH4xadurX259XcPNKdIpLTnczY8zWQr+Wh3X4wZ4Rdkdt+9yNF4TrShUshc+lvPcxD3658hDVgfCc1VLY7p67Lw/RuXjjTwBQmpspwu0GotbfF60V8/Ui616+7t4swgVjFj1/dIzSY7YixHpCa+wdFOxmVgO+DPTG+9zo7u9Y1OcC4EPAFuAQ8MvuvjO230SwKPQA73P3P4/XvBN4FbDB3Qc7NX/RWUpbXgNA9vC1oaHaEwR0s1kIsCRsK9XCLJ2Ec7MFTIZ1+eTslkq7nrUZBmKxk7YypZx9dthPprqeWjDBz9cLT/lyNSwBbLoASwI99p+sVejJS8rGaZdjARgr5S8fNrAJBjYVLw1QvIQA23rDi8N09ISvlYNA7q+MUJoIsfY+Ox7m1157fb7NTJ+WJOrR5D+8FbY/Bib2Qczi1zpUh0OPUN7WjxDrAcNkiqezpvg54DJ3fxqwA7jczJ65qM97gI+4+1OBq4F3xfY9wLPcfQfwDOBtZhZ/lflfwKUdnLdYKZrNk+t/NGe7szaf3BjzR8kQt+mCkxriaD8kC4T6EkjhcAtoF+pLIb4UtCOhLsT6o2Mau7s7kH6ZeuLHF3W7GPituH8r8Il4bXtcUi9tLyDu/lUAU2m+riA3ex9+pBDs7aVWIZRZzfOgzxUXp/1kjt68IQ95s2pwysuzwpUqRehbunfvEN6uvRMd9eJ4M1mIG++rBMOQe0YrzqNaChr4fNZgk8WwtbR0MHO4KGiTzOMpTn52Io/Jnx8IY2wfeBw2FQvkpBzwyZoARbnbFN7X01MsSaRMe+VeiN8l28M8KlMzyjgn1h3KPNdh5zkzK5vZ7cA+4PPu/rVFXb4DvDjuvwgYMrNN8drzzOwO4BHg3e6+u5NzFUIIIbqBjjrPuXsL2GFmo8BNZvYUd7+rrcubgT81s1cT1uN3EVcv3f0R4KnRBP8JM7vR3fcu9d5m9nrg9cv0KKJD2PDLAMju/v+LKm2p+ElaH+8dLPa3x225UjjUHY7rzH0DuXbr6Vx6e/csz6Xuzbm4nYXZGNoW+ztgMQnNXNTYk6m93prONfVaJWjTZavQjNeWJ+N/z8nDsCUkoeFgnBtRcx4dzavMjWbB/O6HHsGTVp4sEzHrHlAsF6QwvZ5anr+ezOO89xSOiOl7zDKy8TYLhxBdj6m6G2fIK97dx8zsVuBy4K629t1Ejd3MBoGXuPvYomt3m9ldwE8BN57EPa8DrotjL14CEEII0WUYMsVDZ73itwDzUaj3Ac8H3r2oz2bgkLtnwFUED3nM7FzgoLvPmtkG4F8D13ZqrmLlKT3xd8gOXh8OktNYWhNPddYBUt50KDzDB+Ja9NxMrsHSFx3rUj75lMQGinrlfaOF1t/TFmoXteENSQOO4WMTbTl0puZDwpn+yggtD/MoJ227t7eo2z4dk+zE5DH01IokOmO7wrmR7XhKVZuS6KTnTnNqZ/xgEQGQaDbhUMpxH+excQR2TiKEWF90UmPfDlxvoX5mCbjB3T9lZlcDt7n7zcBzgHdFjfrLwBvitRcBfxzbDXiPu98JYGZ/CLwC6DezncBfuvt/6eBziDNEadOVC469/qmwbS+yksLGmg2YiubroSiAJ6aLDHZJyM5FAds3XDjZ1drKvJYKU32YRCV3uLPovDcTY9dLzVkGesK1PbFYC1kzF9C5s1ulli8J2IZoCk/x9bW2CM0sZY+bxHpDqVofjAK+LXyOvuHimSG8GPQPLJi3jZ6TLzGkFyM7sI+enxnF73sEIdYFpnA36KxX/B3A04/S/rtt+zdyFPO6u38eeOoxxv1t4LeXb6ZCdC8S6kKsP44p2M3s5iVcf8jdX7180xGiwGr/Jt/PDnw4Nsa38eRs1t5WsiJZzfiiUqozk0UGt72xBGylDMNRG260hc4lbXhoGwA9paA5b+zdTmkyOsPFBDh1GvSmgi8x3I1yW2jdxm2xLSavKfXgWZyjF1njcieQtpKrR1SjSxaHmTpsWRTDX6pgtZRlL4TWeW0cn28hxHrCKJ+4U5dzPI39IuC1xzlvwPuXdzpCCCHEqaHMc4HjCfa3u/s/He9iM/u9ZZ6PEEeltPlXFhz72N/gSbtNmm9PrQgNSxr4TAwza7aKBDiNNge8lGc+a8tBH7Xr+WrYHp4LYWxbWwP5er/FRDiVUhUrRQ05jTlfX5i2FmAyporNssIpLq23NxuFI+DBmD1uuC3cLQ/di32GBhdaBwCf3Fto+3mu/Tlae04ye50QYs1zTMHu7je0H5tZv7vPHK+PEGcKG31Fvu8T8b9hpRdvF5YAlegpXp+DqSjEh6OpvX/gyLrp8/XczN/jQTjPxpzuDJ6HRae8GcL4rVaToXRtcsTLKIRrijdPWfT624RyOlftD57uULx0eFZk1huKWfEGt4dTs4fh0Z3h3Gg0yVerhek+PXvm9Dz7yTS+cCdCrBdUBGYJmefM7F+Z2feAH8Tjp5nZf+/4zIQQp42EuhDrj6V4xV8L/D/AzQDu/h0z++mOzkqIkyBlrzsa2b6/CDszjwbnunZmpgstvprC0Xpz5zmPmeTOG/kRAJreZC7GozdaQavfkNXw/Q+Ga9P4I2e1hdtF7TzGxFttpDDZP3h/2G4cKTT1/mi6H9iYx9tbLTr9JY18duLI8LmeWlEEJpnkt22ncu6Dx/xuhOhGtMa+xFzxMb1rO3K1FUIIIVYhS9HYHzGzfwW4mfUAbwS+39lpCbE8lLa+Lt/Pa7+ndfXZ6cJpLq2Pj2zKk8XkxGps5foU/VFDHkjV4yb2FDnc28LXilzuQXO3wb6F94ZCOx/eBJsWVp4jy7DBLQvG9em4Dr/3AJx9Vpx3qg/fLGrQp4pvtRFs24YjvhMhuhXDlFKWpQn2XwfeC5xDKNLyjxQZ4oRYM5TOf9OS+uUx84sZP5infPVNsURqTw3ri8VcUua3VmNBJjsAP/BwOB7dVpSU3RKEs/UOFd7zKd3s5N5gsq9PFeb2XbHAYZbBxMSC/vSPwnR0FEw/bFam9PRn4A/+gPp7XgRA7c03Lek7EGKtoiIwJxDsMR3se939352h+QghEvXTD1XzB3+wDBMRQqwljivY3b1lZheYWdXdG8frK0S3kGLmW18JmYttSzRxb7sAG9gU9mNpWT/0UBFPn7Tu6TEY3hquTTngm7PFccoj3xfN5O1FXpIZvX8DxHv54eDi4pNR0Nd6gzkesAvPDW2TB2Bf1NgH43xGgM1hDFvsOChEVyJTPCzNFH8/8M8xxex0anT3P+nYrIQQQghxSixFsN8XPyXIc3GovrnoesrP+kMAsu/9fmiYPgTDIUkMPVHLbjVh/6NhP4WgZRm2Jf6pxBC1XNOfnSgc3to1i3xdPG57B/H6eBjivKeF+aSQuLFJSFaEZC2oTxXOeLGkq4/tyu9V3hbW9evvvgKA2ls/sfQvQog1gpnC3WBpgv177v4/2xvM7N92aD5CrDpKF/9ngFAvPnmo90aBWioVNeA3BfM7zUZe+jVhyfu+2l+Y3tMPULNR7Kf4dyuF+PVyhcp0qEXvA/FloT5X1GNPZWpn6nkddp+LTnz3PBTPzVJ6QjTZ79Gau+hulHluaXHsVy2xTQixnCxOd3sqpFz5Qoh1w/HKtv4c8PPAOWb239pODQPNTk9MiNVGadOV+X69+WkAekfPwRsPhsYUetZsYAMhtj2LTnRJI29lTSosMrv7RJFVrt1Mn8aL4W7J/c1bTXxXiK3PS7VWynn2PKuE/n5gJ629wS2m8rjzw3Z7ODf33pfQ+8a/O4VvQYjVjKq7wfFN8buB24AXAN9sa58ElhYQLIQQQogzyvGqu30H+I6Z/U3sd767//CMzUyIVUzLozbdU4Na38KTAxtzbbyU3EzjuvpsawqP+31Rs+5pLzebmK8Xpvh4bn4glHKtTB/EhmKFur5471QKFnKt30pGeXQstoX52GDo17x93/Gf74u/CUD5ue87bj8hVhtaY1+a89zlwHuAKnChme0Arnb3F3R0ZkKsYsqWPOAbRWa4GJ/O9KEQNmIlaARTuI0Eb/oSJaaawdu9kYX178GeDVTTGJGSt3ndx3OVUjK7V6EaasCTYtsH+wsP+fRCsOUsbEssSDMZ7pni3muD/WS/8q/jzaKRf2gkv7/f/0C4/d+9OjTUein/wgeW9N0IsVLYCprizexyQpbWMvCX7n7NovO9wEeAHwcOAr/o7g/Gc1cBryHUYfl/3f1zpzOXpXwD/wW4FBgDcPfbgQtP56ZCdD3L8ePSWgZXlmwZxqj1nv4YQnQxMUvr+4GfAy4GfsnMLl7U7TXAYXd/PKFq6rvjtRcDLweeTFCk/3sc75RZisY+7+7jZgsyVymOXaxrapWfz/ezwx8NO8mcXqkW+5MhQ5zHojADI9vpH74gnGqETHFlqzA1H0zmSSuv1QYppRC5qL3beIiX9707oR6d7VK52UPjMBjj3Ee3FPOIIXBJw7ezHhu2F1bzbHg041jThwoz/vkxF/5FPxru+cPvLvGbEWJlWaHMc5cC97r7/WEO9nHghcD32vq8kKAoA9wI/KkFwfpC4OPuPgc8YGb3xvG+cqqTWco38F0zewVQNrMnmNn7gH851RsKIdYWEupCsNnMbmv7vH7R+XOA9vLmO2PbUfu4exMYBzYt8dqTYika+28CbwfmgP8BfA74/dO5qRDdRGnDKwHwmZjNrVTBx3eF/aS5T4WENV7am5eBHeoLznC2YZj5qKk3WjFrnGdUyyGTXGVyfxjjYByzUoaN4VqardB/7wEs7tMbTeeDmwunuhRGl0q7NmYKn4C9oWqcH57AztkW+0cL3YP3Yr29MDxwkt+KECuDdcaefMDdL+nIyB3ghILd3WcIgv3tnZ+OEGsX6w/pWrM9fxYaempQiWlek0DddT9+ODiy5SloL6jTFwVw/4bzAJj0GeqtGabmD7M9mu49rrnbhvNyoex7Q6CK9fQUE5mPJvlSCar9oUxsNOungjK5UAcYiS8YpVLh4Z8c8VJhGSHE8dgFnNd2fG5sO1qfnWZWIZRpOrjEa0+KE5rizewSM/t7M/uWmd2RPqdzUyG6nlTp7TSYmj982mOk2u+nxcaRE/cRYrXg2fJ/Tsw3gCeY2YVmViU4w928qM/NQMpy9VLgFnf32P5yM+s1swuBJwBfP52vYCmm+L8G3gLcCSzpCYVYz5S2/wbZHe8IBxujpp409qHBtrzxUctuNvLa6z4VNOTBDWdTHQohcpOt6Hi3MbzUjzcOMVqN4/XGMLnBmVwrz9PIbqLQvKej5h2d+Nh/qDCvb4nKQv9o4UWfTPc/8pSwvU855sVawJcqiJf3ru5NM/sPhKXqMvAhd/+umV0N3ObuNwMfBD4aneMOEYQ/sd8NBEe7JvAGd2+dznyWItj3x0kJIdYjEupCnBB3/zTw6UVtv9u2XweOWkDN3d8JvHO55rIUwf4OM/tL4IsEB7o0kb9frkkI0W2Unvp7C46z/R8MO33DRUKbpBXPjOVOcHm1tsYMvdNBo++NTnZzWQhLq1X6aUbjWWVTXH8HOBxD6w4GE75VH8LbQ9kAJmJCm+GBPBtd7uA3Xy9C39qrzW0eJfv6XSf7FQhx5nFWRGNfbSxFsP8K8CSgh8IU74AEuxBLpLTlNUe0ZQ/9MQC25XF5m0ePeebr+Hw9JKmZ3AtAtW809B/exrzFP8UUd771CdC/IbSN7M/HYPpQeGnIFv3YNVtQiy8RrTbze3XhT4LffTcAlZddf3IPLIRYMZYi2H/C3X+k4zMRQixkOTLPNU9rqQ6A8rOvPf15CHFGWJk19tXGUgT7v5jZxe7+vRN3FUIsldIF/xGA1md+HfuJZwBgozEvxXwdn4qa986dYVs9CICf06RnKMWbR5N5pcb8YNToB4NjXWW+gc9Gz/oUA58EfebQHz33U8nYcrXw5k9OdJUyrX9+M+WffM8yPLEQZ4DF1ql1yFIE+zOB283sAcIauwHu7k/t6MyEEKsCCXUh1hZLre4mhOgQ5Z/7c+DPgSK5jQ1uweKauW+ODm+ltrQT9Ri2lpzcehqkFDXN3hDillVrlMoxb3wpnPVqXMPPmtCIiWxmovNctQeqC8vH2tAA2R3vwO97hPKLPnR6DyrEmUCm+CVlnnvoTExECBFi4NtptD5LT4xV9+lgimf6EN4TBLANbAptrSY+F9LWVlJWuWRWL1eZ6Q/CvjwQ3GV6vYTvuyecjyVdGZvEDz4c9lPRmKHowV+r0vzrkDq38u8+evoPKoToGMfMPGdm3zrRxUvpI4Q4NRqtz57+IOXqaQ/h+w+e/jyEOBO4r1TmuVXF8TT2i06QOtYIuW6FEB2gWg6rYD4b8kMlxzpvNYoc9DHczWcO5lnlfGgrsSNmQbPvTxnoauG6pjepxLz0nn64+vqKrHjbNse2Yez8x+Df/rY0dbE2WIOCeLk5nmB/0hKuP/1YGiHEqsa//e2VnoIQ4iQ4pmDX2roQqwPrewHQprkPb8/D0XwmhrPtfxTSengKX8tK+GTIRpdnu8vCn3W5dxBPeeOzompcXvEyafhWwn7sx5n/mwWZMoVYpbjC3ViaV7wQYhWQBHzCZ28uvOI3bi5ONBvBca4xA739cPAATEWHulR4JsWsT49DXywGU6limy/E994TzPqHJvBUArblzP3Ji+n9LSWcFGK1I8EuxBokae9Hpb1k7MEDx+43PX7kuHujp/yhibyt+ZV7ASTUxdpAa+xLqsf+m2a24UxMRgixNKzvBUGDz5rhU65ApRo+pUr4tJowOgojw1CphE9jPnwmDwctfmom5JSfr+MTe0NmuvY0tFlG5RmPxWrSAYRYKyzlr3Ub8I0Y2vYh4HOxOLwQYrWzDNpL6zsPL8NEhDgDqLobALYUGW1mBvwsodLbJcANwAfd/b7OTm95MDO9iIh1Q7b3A2Gn2o+Ve0PbP98S2gaDU5xt2lA4GaWc8Y35oNUDlCxso0nexyegHpzyyr/wgc4+gFgPfNPdL1nuQS95+mP9ti8tW1nzHBt9RUfm2ylOaIqHkBgeeDR+msAG4EYz+8MOzk0IsQrw8YkTdxJCrBpOaIo3szcCrwIOAH8JvMXd582sBNwD/HZnpyiEOBlK235tSf2y7/1+2CnHn4ENo2G9HWAgVIijNoidfTbMTBae9UKsYtyVXmUpa+wbgRcvjmt398zM/k1npiWE6DSli/8zANm3/lNo6J+FzbFs7OJY4Ikp/JE9Z3B2QohTZSlFYN5xnHPfX97pCCFWHY9KoIs1gitBDXQwjt3MasCXgd54nxsXvySY2QUET/stwCHgl919Z2y/ieAD0AO8z93/PF7z48BfAX3Ap4E3yktfiFOn9GN/kO/njncpF325AuecB3t2UX7hB1dgdkKcJPKKX5rz3CkyB1zm7k8DdgCXm9kzF/V5D/ARd38qcDXwrti+B3iWu+8AngG8zczOjuf+DHgd8IT4Ub14ITrJnl0rPQMhxEnQMcHugal42BM/izXri4EYh8OtwAvjtQ13n4vtvWmeZrYdGHb3r0Yt/SPAFZ16BiHWG6Vtvxac7/Y8GD6VGpz3OOiv0br1jbRufePKTlCI46KyrdBZjR0zK5vZ7cA+4PPu/rVFXb4DvDjuvwgYMrNN8drzYtnYR4B3u/tu4BxgZ9v1O2ObEGIZadz8LRo3fwvmpsJn43bsvPARQqxuOirY3b0VzennApea2VMWdXkz8Gwz+zbwbGAXsRSsuz8STfSPB640s20nc28ze72Z3WZmt532gwixnkmV3oRYC0hjPzNFYNx9zMxuJayH39XWvpuosZvZIPASdx9bdO1uM7sL+CngnwkvCYlzCS8DR7vndcB1cWw51wlxEtR+55MANEZD5rqeV1yBx2x0rX96EwDlZ1+7MpMT4pj4mhTEy03HNHYz22Jmo3G/D3g+8INFfTbHRDcAVxE85DGzc+M1xAI0/xr4obvvASbM7Jkxze2rgE926hmEEEGoCyHWDp3U2LcD15tZmfACcYO7f8rMrgZuc/ebgecA74oa9ZeBN8RrLwL+OLYb8B53vzOe+/cU4W6fiR8hRAew/h6an/gHyi+8HGqDoW37FgBa//xmeDSUhS2/5K9WaopCFDiKY2eJRWDWOjLFC3F6ZA9fC33D4aAU9QHPKG3+lZWblFjLdKYIzNMu8G987qrlHpbS9t9YU0VgVGRZCHFcsoe1li7WEFpj76xXvBBi7VM6/03YyHasdyh8Kr1YpRfG9q701IQQR0EauxDiuPj4x1d6CkIsEXnFgwS7EOI4ZH4LDlh9ChqhbKtP7Q/bO+9ewZkJcQwk2CXYhRDHZrJxCIBhr+QCnbkg4Ft7p1dqWkKI4yDBLoQ4LsMt/UyINYLKtgIS7EKIozA+dyMA/ZVhmhUo770HxkNSSH8k1Gdv7pk65vVCiJVDgl0IcVzKe+9Z6SkIsXS0xi7BLoQ4kqHqRgBs8gAMbsEfvRdm6uHkcMhAV97cT+srvx32n/WHKzJPIY5Agl2CXQhxJNZqLmwYGML3H1rQVHnsRpiQOV6I1YYEuxDiuPikEtGINYKc5wAJdiHEUbDKzwLgkzdiw9vxuUlsZCicnArhbmwaZf5r967QDIUQx0KCXQhxXHxucqWnIMTSyVTzS4JdCHFMbOilAPjY3+BnnR8adz4Q2ianKG3sW6mpCXF0ZIqXYBdCnBgbfQXZ4Y+G/QsvDo0zhylv2wxA65OvAaD8wg+uyPyEEAUS7EIIIboDOc8BKtsqhFgipQ2vpLThlUzUKkzUKtimC2B0C4xuwS7ZgV2yg+zrV630NIVYVZjZRjP7vJndE7cbjtJnh5l9xcy+a2Z3mNkvtp37KzN7wMxuj58dJ7qnBLsQQojuIfPl/5webwO+6O5PAL4YjxczA7zK3Z8MXA78VzMbbTv/FnffET+3n+iGMsULIU6Kkd7oUDd5Iza0LTTOh6x0fmE/2UN/HPbvfRCA8nPfd8bnKMQq4oXAc+L+9cCXgLe2d3D3u9v2d5vZPmALMHYqN5RgF0KcOuXwE+Izs+F48gDsCxnqJNDFGcdZjWvs29x9T9x/FNh2vM5mdilQBe5ra36nmf0uUeN397njjSHBLoQQokvomPPcZjO7re34One/Lh2Y2ReAs45y3dsXzM7dzeyYtn0z2w58FLjSPU96fxXhhaAKXEfQ9q8+3mQl2IUQp0arAa3qwrZ6A5+tr8x8hOgcB9z9kmOddPfnHeucme01s+3uvicK7n3H6DcM/APwdnf/atvYSdufM7MPA28+0WTlPCeEEKJ7WH3OczcDV8b9K4FPLu5gZlXgJuAj7n7jonPb49aAK4C7TnRDCXYhxClho6/Aa4N4bTBv88PjtH74KK0fPkr28LVkD1+7gjMUYlVwDfB8M7sHeF48xswuMbO/jH1eBvw08OqjhLX9tZndCdwJbAb+4EQ3lCleCHHKWD2Wba30hu0TL6LyxIvggXvxb965chMT65NV6Dzn7geB5x6l/TbgtXH/Y8DHjnH9ZSd7Twl2IcTy8oAqvomVYllM52seCXYhxKnTCCVcvTENgFUH8LO2AjD/he+t2LSEWM9IsAshhOgOVqEpfiWQYBdCnDLejHky5sJau1eq0DcMQGljbaWmJcS6RoJdCCFE9yCNXYJdCHFqZH4LHHwoHJTCT4lZGY/ae3nbAACtf/i1cPwLHzjzkxTrDMddznOKYxdCnBKWZSFXfLkC1X6o9hemecCefhH29ItgsB8G+2n905tWcLZCrB+ksQshhOgO5DwHSLALIU6S2eanwo6VsIFNsXEibD3Da8F5zqrBFE8l5pOfmiS795qwPzYZtiWj9GMnTKQlhDgJJNiFEEJ0D9LYJdiFECdH2eLPRrOeO83RPxq2rSbWagDgs+OhLWrw9NSgGc5x4HDos/fAmZiyEOsKCXYhxJJotD4LgCWf26wJ8zFXfNSSvDkLk1FYJyFejj8zPbXCLN8fY9wrFRp/8XIAqq/7eEfnL9YDSikLEuxCCCG6BTnPARLsQogl4NktuIX9VtYsTszXw9aiFj95IGjyAFMhjzy13oV92trsvLPw+w+FcW/6VQDKL/rQss9fiPWEBLsQ4rh4dstKT0GIpSONXYJdCHFsvPmPkDXxciXX1Cvph7M+UTjIHT6KE1w9rrHPRK1+e2+htQ9tCNtancqO88L+RKgQN/t7/4a+d3zqhHPLdr0v7PTUKG193Uk9lxDdjAS7EOIIFmvp7hmlJJSb9eLEwX1hm4T96GheBIZsZ9g25sO22l84zyUTfk8NO/+csB+d7Hq3bSZ70Y8X4wGl80PWuuzAh/FvfgOA1i1fC31acpYSEZfzHEiwCyFOQIZMm2INIVO8BLsQ4kiSMG95ML83WnUG5uMPZgpt23lPoY0nLalcKcztw0lzj850c1OQUsknzb3aX4TD9Q6G7Xm10A4wMxaGSGb3+Tq242kAlH7wg9D01QdO82mF6C4k2IUQx6XRqp+4kxCrBWnsEuxCiIBntzDvweEtaeqVUpVKqYo5+PSu0DElnhnsLzTrpKXP17FKDG8b2R7GnTlc3CRp754V23RtyjdfrmC1kbA/HMdozobj+hRUQnIb6wvb2ls/cTqPLUTXIcEuxDrHZ28GYC6r08yC0B7I4k9DKQrgZqPQhJJw7h080hmutx9vBfO89fTFMaLgrtSKayZsmWEAACAASURBVNPLQbMBczMLJ1SuFII/XmulnjDXUgkmg8OeHx4/1UcW3Yqc54AO1mM3s5qZfd3MvmNm3zWz3ztKnwvM7ItmdoeZfcnMzo3tO8zsK/G6O8zsF9uuuczMvmVmd5nZ9WamlxMhOkkSwkKsBbJs+T9rjE4KxTngMnefMrMe4P+Y2Wfc/attfd4DfMTdrzezy4B3Aa8EZoBXufs9ZnY28E0z+xwwAVwPPNfd7zazq4ErgQ928DmE6G6i01ov0FOKGnjK9x41cp85DI2oWSftPIW1tfUrbX0d2UN/HK5J52OhGOvpw+ejST398hw8WMS7V8phO7w1N897I8S252b6mUn8zrsBZagT4lh0TGP3QKwQQU/8LLaRXAykgNlbgRfGa+9293vi/m5gH7AF2AQ03P3ueM3ngZd06hmEEIvWyIVYzaRc8dLYO4eZlYFvAo8H3u/uX1vU5TvAi4H3Ai8Chsxsk7sfbBvjUqAK3Ef4Z6uY2SXufhvwUuC8Tj6DEN1OCm0zK1GajyVXk6Y8vidsG3PFD1y1J16YQSX+hMS18+z+d0MrrqOnbVqHL1egFXWJRnLAG4L+OG7S8MsVfDr+BNRT9bioE1TKzN2+97SeV4hup6OC3d1bwA4zGwVuMrOnuPtdbV3eDPypmb0a+DKwC2ilk2a2HfgocKV78KYxs5cD15pZL/CP7f3bMbPXA69f/qcSojuYng9OcxbN3o1Wnd7WIq/1Rgw8bzYLJ7ieWHK11YDmIqNfswW16DQXBXru4Q6Ed32gL7T57HjhoJeYnYCp6BiX4uTjvf2HD5CNzyHE0ZHzHJwhr3h3HzOzW4HLgbva2ncTNHbMbBB4ibuPxeNh4B+At7evy7v7V4Cfin1+FnjiMe55HXBd7Kd/aSFOlWbzxH2EWC2sQdP5ctMxwW5mW4D5KNT7gOcD717UZzNwKGrjVwEfiu1V4CaCY92Ni67Z6u77osb+VuCdnXoGIbqZcgwoScVdSlbC61FTPrTI3N3XV5jUD4cyq/TXihj06CBXeuLvkO18b2jLz8VtlkE5OeNFU/v4waKsaz6xSnFN0tRjaFt2aBor2ak8rhDrho45zwHbgVvN7A7gG8Dn3f1TZna1mb0g9nkO8EMzuxvYRiGkXwb8NPBqM7s9fnbEc28xs+8DdwD/y91VU1KITtLXt9IzEGJpOHjLl/2z1uiYxu7udwBPP0r777bt3wjceJQ+HwM+doxx3wK8ZflmKsT6JA9ti2QO1jsEgOdOcRnMzYV18xTmlta9my1IEW8DoQpbdu81uVaeHOpyr/pSBSsHx7v8PkONYs0+XecZDMR1+Wq4p00EJ7rS5kFKI2On9dxCdDtK7iLEOsSb/4hHU3nugWIUyWiSuTstV85Mw9TswkFqPUUBlzwrXVaY0ZOgTmVemw28Fgu9JCe9/tE8q1xu6s8yqA6EeU7tD22DMXVtq0XlgsIZT4gjkPNcR03xQohuQM5IQqwppLELsQ6xys/iEzcAUO8P2nCtSRE/Xo3m8WStb9ShGk3ww1HrrvYXGn7KSlftwfo2xJskzT3meW9M5+FuHqPemK9DtVyMB8ERL4bbWTLnp/H37CebVIpbcQzcYQ2uiS83EuxCiOPTUNlWsTZwwGWKl2AXYt0SndZS2JsfvAfGo2PaQFs51ko1rKWn9fS0Ft5stCWtCf2TUxwUpVbzpDTlKiFnVdHm9Sk8ZZeLeeTzqnCAN2MympjPnv6algaEOAES7EKsU6wvRJ2Oz4XAlKFSpRCas9FRLk8f2yxSvrYVgUlZ5WzopaHbgQ9j1UUOdZW2MdJPTjkK+0oVDoQyrIyFlwqv9QaPeyiS47R56Xv9qMkmhQgqu0zxcp4TQpyAkn4mhFhLSGMXYp0z0hu0bZ/++6L8YnJWm5sDQv730rZfAyA7/FEArDqQO8hlBz4c+lsJn5sM+6nkayooM9+2Vj+0LWx7asWLQ3+KZ69AI5rnU1a6aDmw5hA9jx89recVXYwDLS3VSLALIY5PTZnnxFrB5TyHBLsQ6x4f/zgAkz0wtPnC0Lb/vnBybg7qszA4kmvluTPcfD1UZwOIiWes3IuP7QptydkuhbFBEQJXKbLM+XjU8PceCF0uOKfQ3lPYXWKmjv3IhafxtEJ0PxLsQqxz5gaCU1wV8JgtzjacB4DHOHIaM4VpfWqiuLi8MC2tt+ZgYGNxDW2e8v0birj3uWhqtxKMRcGest2NTcLmYG73R+JLQkxjmz2wj/IlRy3oKISc5yLyihFCHJ+mEsIIsZaQxi7EOqd3PmjlWW8/zSwI8Z5cU48Ob/UGVKOAT6b1+hSUoqNSyv1uJaw/Zp7rX5SBro28MMx8HTvvrNA2HUPsKmX8gZ2hbX8IgbO+YBkoDfXg0WQvxFHRGrsEuxDiBNSlsYs1Qizbut6RYBdineOTewGw6Qps2B4ao1ZuG+Na+9R+Sme/AYBs9/vjhVmhvbevxSdNffG52Qk8ZZdL1ds8g81bQ1sW5uGz9SK8rTdmxZsOGeha+2fxB8aX5bmFOBOY2Ubgb4HHAA8CL3P3w0fp1wLujIcPu/sLYvuFwMeBTcA3gVe6+3HftiXYhVjnlLa+bsFx9uAfMXn24wAYGg5mcrxFtu8vwn6KR++pFftJePfU8Ik92NC24lzc+twkzMTscjGLXcpc5/OzsDmMYYcOhbb9h7Bz4v3Hg8Nepa+H+R8cXIanFt2Jr8aUw28Dvuju15jZ2+LxW4/Sb9bddxyl/d3Ate7+cTP7c+A1wJ8d74ZynhNC5GQP/tERbT6+66TGsJR8ZokkLX5B2/5DJzWGEKuYFwLXx/3rgSuWeqGZGXAZcOPJXC+NXQiRU3rMWxYce+sL2PB2rPy8QmOPznCls99Atut9oa0tVt2n9oed5FDXruHHcqxMRa18vl7EtKcxztuInRcHixq+1WKoXf80lbkw7vxHfzkM+8qPnfLzii5jdYa7bXP3PXH/UeBYb741M7sNaALXuPsnCOb3MXePf0zsBM450Q0l2IUQx8XKz1vpKQix0myOQjdxnbtflw7M7AvAWUe57u3tB+7uZnasN48L3H2XmT0WuMXM7gROyaFEgl0IcUwyg1b2BUrTY4UmHrXubP8Hi45JE/esSFqzeP19uu03KiacoVTKy8em9Xaq/XkCG0/jpnXTxjw+F6q7tXbHPpM35tXlhOhQStkD7n7JMe/pfsy3XzPba2bb3X2PmW0H9h1jjF1xe7+ZfQl4OvB3wKiZVaLWfi5wwrUxrbELIY5LaXpspacgxNJIpvjl/pweNwNXxv0rgU8u7mBmG8ysN+5vBn4S+J67O3Ar8NLjXb8YaexCiGNSLgVF5MDs37CpL3qwp+QynuUe9dme6KRbrkArRuIcjg5wg3HtvFIu6qwnjX1qBs4LeeZzzb4+gU9Hz/eJiQVjWLNFaTSmo40/uNm/3ELrn98c2maClaD8/D89nccWYjm5BrjBzF4DPAS8DMDMLgF+3d1fC1wEfMDMMoLCfY27fy9e/1bg42b2B8C3gQ8uvsFiJNiFECdkc98ryPyWcNCWNS53qEtlXqEwuU/FtkosGjM4BBaF97bt+RjJjJ8XlCmVYDaWek0m+FTatVLOhXz5x3cU944vCqUn/s5pPadY6yyLhr2suPtB4LlHab8NeG3c/xfgR49x/f3ApSdzT5nihRBCiC5CGrsQYkmU7DIAfP6zoWH6EN6YXtSpVFRpG44m9lpv2LaacDhq5aNRE+8dLLTxFB5Xn4Fm3B8djWOEhDYMbaV0fshKl8LuvDGDH5QfgCCklFWueAl2IYQQXURr1WWeO+NIsAshTgrruRwAr38K5lIt9fhTUp8qHORivvcUzsZ8kQOeiegAt7EK2SKNfW4ORjaFew1vWzhGs5H383TvtvFa//QmAMrPvvY0n1KItYsEuxDilMiqNUqDWwDwvfeExgNjeCsIdhsZCm2VGM9eqUItZZ6LQvzQITjr3LDfH4X3QJYXiUn4RCxUU+nNTfDW0xfO9Q7mZn+/fw9i/eIyxQNynhNCCCG6CmnsQohTolx6Hj5xQziI1dqozWCpfvviKlvVfqjHgi/JJD+8ocg8V4ka+ORe/OCi5FoxdM63bsGilSCnp4YNhGtbMyHsrf7uK6i99ROn8XRibbL6wt1WAgl2IYQQ3YEDMsVLsAshTh3fdz8A9pgfCw39G4rMdIcPhG1ylLMS1IJmzVR0fJsaDw5xgJcrRb+JGEYXq7qxNWrpExN4crIb3By6V3rxsx8DQOXZIbROZV/FekaCXQhxypQe/zYAfPzjADQHN1Kux1j1FIteiT8z4xOFNpVM8c156I1x7qlsa7MBg/EFIHnYJ7P+hs1F6tlmcMrzxkxIZQv5i4NtGCH71n8Kc/yxP1iGJxVrBZcpXs5zQgghRDchjV0Icdr4ZAhHa/T305cywk1HR7mkbSftG7ChGM422J+HryWTPNPjhSk9XmPD0TnPs6JE7FzMRV8qFVp82taqefhc9vWrQrdL3xWGvOFKSs94ami74D+e+kOL1YfW2AFp7EIIIURXIY1dCHHalM59IwCt7At5pTfrCevoPj6R97OBuI6+cSReWAmJawAmo9NdlmFPenLYn4/JbXpj3vn2KnLtOeaT1p+2JQoLwbbgZJcdvL64dnLfyT+kWAO4UsoiwS6EWEbKpecVtdmjR7vVgmClvwZDmxdeMDtRmNaTIO6v5W02EFLLJsHuc1NHCvH6LIzG1LNz0QN//358Or5gPClUw7T+DfltPY6f/SA41pWe9J9O7YHF6kKZ5wCZ4oUQQoiuQhq7EGJZKW3/jQXHKTudt+YKDTydmz5UOLxVynGAStDkAT8UnPLy0q9ZBtXawhtmWaG95zHu/dhozFXfinHy0cEvv0f7uKJ7ULibNHYhhBCim5DGLoToKDb8snw/ObDZUMgkZ9t+BOt7QTj3cFup1fmQ851G3FbaEtAkbTs50tXnYCpmuUuae7UXatHhbnF4XNYsxt24/fQeTqwutMYOSLALIc4gpU1XHvvc+W86qbGy3e8PO8MULwLt2e5SDffkPZ+2PYOQRU99lwd1t6HMczLFCyGEEF2FNHYhxJqkdPYbAMh2vQ8asahMMsNOTAUTPcDQIpN8s5Gb6UtbXnOmpivOAO4uUzzS2IUQQoiuQhq7EGJNUzrnN4uscvW4dp4dwsejFn84VJuzVEWuvwb1MQBaN/0qAOUXfeiMzVd0lkxr7J0T7GZWA74M9Mb73Oju71jU5wLgQ8AW4BDwy+6+08x2AH9GcItpAe9097+N1zwX+COCtWEKeLW739up5xBCrH6SU14u4LdUsVga1vfsD9tUWKbaAzOhQE02PndmJyo6i7zigc6a4ueAy9z9acAO4HIze+aiPu8BPuLuTwWuBt4V22eAV7n7k4HLgf9qZqPx3J8B/87ddwB/AygXpBBCCBHpmMbu7k7QqAF64mfxq9TFwG/F/VuBT8Rr724bZ7eZ7SNo9WNxjFjDkRFgdyfmL4RYe1hfLC7TGsDLMVf9xDQAfiAUmZn/zqNQDTpN9fIdZ36SomM44JlCGDvqPGdmZTO7HdgHfN7dv7aoy3eAF8f9FwFDZrZp0RiXAlXgvtj0WuDTZrYTeCVwTafmL4QQQqw1Ouo85+4tYEc0o99kZk9x97vaurwZ+FMzezVhPX4XYU0dADPbDnwUuNI9zyTxJuDn3f1rZvYW4E8Iwn4BZvZ64PUdeCwhxCrF+q8AwBufxmJbbiaMpWJtaJrKuSGPfOkp70B0Ee5KUMMZ8op39zEzu5WwXn5XW/tuosZuZoPAS9x9LB4PA/8AvN3dvxrbtgBPa9P8/xb47DHueR1wXbxO/9JCrCOs+vN48x/DwXnnh+3dPwzbLGP++wdXZmJCnAE6Zoo3sy3J4c3M+oDnAz9Y1GezWUruzFUED3nMrArcRHCsu7HtksPAiJk9MR4/H/h+p55BCCHE2sIzX/bPWqOTGvt24HozKxNeIG5w90+Z2dXAbe5+M/Ac4F1Ro/4y8IZ47cuAnwY2RTM9hLC2283sdcDfmVlGEPS/2sFnEEKsUazyswD49N+HhgtCEZhKpcLcZ7+7UtMSncSVKx466xV/B/D0o7T/btv+jcCNR+nzMeBjxxj3JoI2L4QQQohFKPOcEKKrsYEQeJMd+HA43jBNZfvgSk5JdJC1aDpfbiTYhRDri+ENlC86e6VnIUTHkGAXQgjRFbhDJo1dgl0IsT6wwS1hpz4BF4YQuMZfvByA6us+vlLTEsuK4thBZVuFEEKIrkKCXQixrvC5SfAMPKO8uZ/y5n6af/3KlZ6WWA5ccewgwS6EWE9UqsV+LXjG2088LW9qfeW3z/SMhFh2tMYuhFgfRKFu/Zvy/PFJqJee9RQJ9S5hLWrYy40EuxBifZCyV/f2Y739YX92AgCvj1N+1ltXaGJiuXBlngNkihdCCCG6CmnsQoh1gZeCHmPzGcxNhba5yXBy/6MrNS2xrDieZSfu1uVIYxdCCCG6CGnsQoh1gaX19LlJSFpdPWju1HpXaFZiWdEaOyCNXQixTrD+K7D+K8J+dQCrDkCpFD5A6zO/Tuszv76SUxRdiJltNLPPm9k9cbvhKH1+xsxub/vUzeyKeO6vzOyBtnM7TnRPCXYhhBBdwypMUPM24Ivu/gTgi/F44Zzdb3X3He6+A7gMmAH+sa3LW9J5d7/9RDeUKV4Isa4obXglPv/ZcDAbw97KVeyix63cpMSysEqLwLwQeE7cvx74EnC82MqXAp9x95lTvaE0diGEEOL4bDaz29o+rz+Ja7e5+564/yiw7QT9Xw78j0Vt7zSzO8zsWjM7oUOINHYhxPpj+lDY9tQAKG1VrvhuoUPOcwfc/ZJjnTSzLwBnHeXU29sP3N3N7JgTNLPtwI8Cn2trvorwQlAFriNo+1cfb7IS7EKIdUtpgwS6OH3c/XnHOmdme81su7vviYJ733GGehlwk7vPt42dtP05M/sw8OYTzUemeCGEEN2BL7/j3DI4z90MXBn3rwQ+eZy+v8QiM3x8GcDMDLgCuOtEN5TGLoRYd9joK1Z6CqJDrMI49muAG8zsNcBDBK0cM7sE+HV3f208fgxwHvBPi67/azPbAhhwO3DCmEwJdiGEEKJDuPtB4LlHab8NeG3b8YPAOUfpd9nJ3lOmeCGEOArZw9eu9BTEyeKrMo79jCPBLoQQRyPWbxdirSFTvBBCiK7AYU1q2MuNBLsQQhyF0tlvWOkpiJNFRWAAmeKFEEKIrkIauxBCiC7BV2Ou+DOONHYhhBCii5DGLoQQoitwIMtWehYrjzR2IYQQoouQxi6EEKI7cGnsIMEuhBCii5BglyleCCGE6CqksQshhOgKHFC0mzR2IYQQoquQxi6EEKI7kPMcIMEuhBCiS1Ace0CmeCGEEKKLkMYuhBCiO5ApHpDGLoQQQnQV0tiFEEJ0DdLYJdiFEEJ0CXKeC8gUL4QQQnQR0tiFEEJ0B3KeA6SxCyGEEF2FNHYhhBBdgdbYAx3T2M2sZmZfN7PvmNl3zez3jtLnAjP7opndYWZfMrNzY/sOM/tKvO4OM/vFtmv+t5ndHj+7zewTnXoGIYQQYq3RSY19DrjM3afMrAf4P2b2GXf/aluf9wAfcffrzewy4F3AK4EZ4FXufo+ZnQ1808w+5+5j7v5T6WIz+zvgkx18BiGEEGsFrbEDHRTs7u7AVDzsiZ/FBfUuBn4r7t8KfCJee3fbOLvNbB+wBRhL7WY2DFwG/Eon5i+EEGLtEUTP+qajznNmVjaz24F9wOfd/WuLunwHeHHcfxEwZGabFo1xKVAF7lt07RXAF919YvlnLoQQQqxNOirY3b3l7juAc4FLzewpi7q8GXi2mX0beDawC2ilk2a2Hfgo8CvuvtjA8kvA/zjWvc3s9WZ2m5ndtgyPIoQQYpWTnOeW+7PWOCNe8e4+Zma3ApcDd7W17yZq7GY2CLzE3cfi8TDwD8DbF63LY2abgUsJWv6x7nkdcF3sL9uMEEKIdUEnveK3mNlo3O8Dng/8YFGfzWaW5nAV8KHYXgVuIjjW3XiU4V8KfMrd652avxBCiDWGS2OHzpritwO3mtkdwDcIa+yfMrOrzewFsc9zgB+a2d3ANuCdsf1lwE8Dr24LbdvRNvbLOY4ZXgghxPpEgh1sPXgQyhQvhBCrim+6+yXLPegTKzX/b8MXLPew/Nzhuzsy306hzHNCCCG6AmWeCyhXvBBCCNFFSGMXQgjRHSjzHCDBLoQQokuQKT4gU7wQQgjRRUhjF0II0R3IFA9IYxdCCCG6CmnsQgghuoZMWUuksQshhBDdhDR2IYQQXYG84gMS7EIIIboDOc8BMsULIYQQHcPM/q2ZfdfMMjM7Zr55M7vczH5oZvea2dva2i80s6/F9r+N1U+PiwS7EEKIriCZ4ldZdbe7gBcDXz5WBzMrA+8Hfg64GPglM7s4nn43cK27Px44DLzmRDeUYBdCCCE6hLt/391/eIJulwL3uvv/be/uY+wq6jCOfx9SKMRSqi1VSsEqdAONwQUKVATFWgg2hpdQLIiWgC+ppkUlNUbxhRRJICaSEEEpAQrl/cVqA8VVBKOQlrbC0kIri2011DYhYLFgyovw84+ZTS/b3e7bOffunvt8kpOel5lz59e7986dOefMbIqIt4C7gTMlCZgO3J/T3Qqc1dtr+hq7mZlVxjC9xn4w8GLN9hbgBGAs8GpE/K9m/8G9naxZKvaXgX82uhA1xpHKVFVVjw8cYxVUPT4YujEWP2k6sJk32y6gY1wJp95X0pqa7UURsahzQ9IjwIe6yXdZRPy2hPLsUVNU7BFxYKPLUEvSmojo8SaK4a7q8YFjrIKqxwfNEWOtiDi9Qa87Y5Cn+BdwSM32xLzvFWCMpBG51d65f498jd3MzKyxVgOT8x3w+wDnAcsiIoDHgFk53YVArz0ArtjNzMxKIulsSVuATwAPSWrL+ydIWg6QW+PzgDZgA3BvRDyXT/E94FJJfyddc7+pt9dsiq74IWhR70mGtarHB46xCqoeHzRHjENaRCwFlnazfysws2Z7ObC8m3SbSHfN95lSS9/MzMyqwF3xZmZmFeKKfRAkHSLpMUnr85CB3+omjSRdm4cDXCvpmLy/VdKKnG+tpNk1eRZL2iypPS+t9YyrS/nLilGSrpTUIWmDpEvqGVdNOcqK7y81799WSb+pZ1xdyl9WjJ+V9FSO8XFJh9czri7lLyvG6TnGZyXdKqlhly8HGeOHa96r5yTNrclzrKR1Oc+1klTPuKwEEeFlgAtwEHBMXt8f6ACmdEkzE3gYEDANeDLvbwEm5/UJwDZgTN5eDMxqdHwlx3gRcBuwV94eX6X4uuR/AJhTwfewAzgyr38TWFylGEkNnxeBlnxsIfCVYRrjPsDIvD4K+AcwIW+vymmV836uUTF6KWZxi30QImJbRDyV118j3c3YdVSgM4HbIllJeibxoIjoiIgXct6twEvAkHreHkqN8RvAwoh4Nx9/qQ7h7Kbs91DSaNKQkA1rsZcYYwCj8/oBwNaSQ+lRSTGOBd6KiI6c/w/AOXUIp1uDjPGtiHgzpxlJ7q2VdBAwOiJWRkSQfmz3OmSpDW2u2AsiaRJwNPBkl0PdDRX4ng+jpONJv6g31uy+MnelXSNpZOEFHoCCYzwMmC1pjaSHJU0uo8z9UcJ7COlL8o8RsaPIsg5UwTF+FViu9CjPl4Grii9x/xUY48vACO2akWsW7x1EpGEGEmPuyl+bj1+df8QcnNPslt6GL1fsBZA0itTd+u3+foHnX8xLgIs6W6/A94EjgOOAD5CeY2yoEmIcCbwRaVSsG4Gbiyxvf5UQX6fzgbuKKeXglBDjd4CZETERuAX4eZHlHYgiY8wt2POAayStAl4D3im6zP010Bgj4sWIOAo4HLhQ0gfLKqM1liv2QZK0N+lDdkdE/LqbJD0NFdjZTfsQaTzhlZ0Jcpdb5K6zW+jnM4xFKyNGUsug81xLgaOKLndflRQfksaR3ruHyih3fxQdo6QDgY9HRGeL8R7gxJKK3yclfRZXRMTJEXE8adrNDhpoMDF2yi31Z4GT87GJe0pvw48r9kHId4/eBGyIiJ5aK8uAOflu1WnAfyJim9KwgUtJ18Pur82QWw6d5z+L9CFsiLJiJF1z/kxe/zQN+sIsMT5IXbcPRsQbpRS+j0qKcTtwgKSWvH0q6ZpvQ5T4WRyf/x1J6jn7VWlB9GKQMU6UtF8+z/uBk4DnI2IbsEPStHz+OfRhyFIb4mII3ME3XBfShyOAtUB7XmYCc4G5OY2A60jX7NYBU/P+LwFv1+RrB1rzsUdz2meB24FRFYxxDKmFtA5YQWr9VSa+fPxPwOkV/js9O6d9Jsf60QrG+DPSD5bnSV3fw/V9PDXneyb/+/Wa804lfddsBH5BHrjMy/BdPPKcmZlZhbgr3szMrEJcsZuZmVWIK3YzM7MKccVuZmZWIa7YzcysTyTdLOklSX16BFfSF7Rr0po7yy6fJb4r3szM+kTSp4DXSc/8f6yXtJOBe4HpEbFd0vho0JwQzcYtdrM6kzRJ0k5J7QWdr1XSzAHkm600VeeDRZTDqi8i/gz8u3afpMMk/U7SX5WmKz4iH/oacF1EbM95XanXiSt2s8bYGBGtBZ2rlTRQyW60h/nDI+Ie0kQuZoOxCJgfEccCC4Dr8/4WoEXSE5JWSjq9YSVsMq7YzQok6TilWfn2lfS+fG2xty7LSZL+JmmxpA5Jd0iakb8QX1CacYx8vpslrZL0tKQz83CoC0kz5bXnVvjlkpZIegJYIulASQ9IWp2XT9bhv8KagNKENCcC9+UeqBtI88YDjAAmA6eQJkO6UdKYRpSz2fT4a97M+i8iVktaBvwU2A+4PSL6cqPR4cC5wMXAauCLpCFEzwB+QJoz4DLg0Yi4OH9BrgIeAX5MGjp0HoCky4EpdwuzGQAAAcxJREFUwEkRsTPftHRNRDwu6VCgDTiyqJitqe0FvNpD79MW4MmIeBvYLKmDVNGvrmcBm5ErdrPiLSR9eb0BXNLHPJsjYh2ApOdIc7iHpHXApJzmNOAMSQvy9r7AoT2cb1lE7MzrM4ApaY4PAEZLGhURr/c1ILPuRMQOSZslnRsR9+WJZI6KiGdIEz2dD9yiNNNhC7CpkeVtFq7YzYo3FhgF7E2qfP/bhzxv1qy/W7P9Lrs+pwLOiYjnazNKOqGb89W+5l7AtGjwLHM2/Em6i9S1Pk7SFuAnwAXALyX9kPQ3fzdpspk24DRJ60nz2H83Il5pSMGbjCt2s+LdAPwI+AhwNTCvoPO2AfMlzc+t+aMj4mngNWD/PeT7PTCfNFMZklojopA78q25RMT5PRza7ca4SM9SX5oXqyPfPGdWIElzgLcj4k7gKuA4SdMLOv0VpBbR2txdf0Xe/xipq71d0uxu8l0CTM039a0nTfNpZhXlAWrM6kzSJODB3gb4qAdJpwALIuLzjS6LmRXDLXaz+nsHOKCoAWoGKrfurwe2N7IcZlYst9jNzMwqxC12MzOzCnHFbmZmViGu2M3MzCrEFbuZmVmFuGI3MzOrkP8DlMUzvcFLfMkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 576x576 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plt.figure(figsize = (8,8))\n",
     "ndvi_anomaly_output.plot(vmin=-1, vmax=1, cmap = RdYlGn)"
@@ -1328,7 +1170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
+++ b/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
@@ -24,130 +24,10 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: datacube_utilities from git+https://github.com/dtip/datacube-utilities.git#egg=datacube_utilities in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (0.0.1)\n",
-      "Requirement already satisfied: hdmedians==0.13 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.13)\n",
-      "Requirement already satisfied: ruamel.yaml==0.16.6 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.16.6)\n",
-      "Requirement already satisfied: lcmap-pyccd==2017.08.18 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2017.8.18)\n",
-      "Requirement already satisfied: ipyleaflet==0.12.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.12.3)\n",
-      "Requirement already satisfied: distributed==2.12.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2.12.0)\n",
-      "Requirement already satisfied: descartes==1.1.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.1.0)\n",
-      "Requirement already satisfied: datacube==1.7 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.7)\n",
-      "Requirement already satisfied: geopandas==0.7.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.7.0)\n",
-      "Requirement already satisfied: rasterstats==0.14.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.14.0)\n",
-      "Requirement already satisfied: folium==0.10.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.10.1)\n",
-      "Requirement already satisfied: scikit-image==0.16.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.16.2)\n",
-      "Requirement already satisfied: scikit-learn==0.22.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.22.2)\n",
-      "Requirement already satisfied: seaborn==0.10.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.10.0)\n",
-      "Requirement already satisfied: dask==2.12.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2.12.0)\n",
-      "Requirement already satisfied: xarray==0.15.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.15.0)\n",
-      "Requirement already satisfied: matplotlib==3.2.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (3.2.1)\n",
-      "Requirement already satisfied: boto3==1.12.28 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.12.28)\n",
-      "Requirement already satisfied: shapely==1.7.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.7.0)\n",
-      "Requirement already satisfied: scipy==1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.4.1)\n",
-      "Requirement already satisfied: numpy in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from hdmedians==0.13->datacube_utilities) (1.18.1)\n",
-      "Requirement already satisfied: Cython>=0.23 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from hdmedians==0.13->datacube_utilities) (0.29.15)\n",
-      "Requirement already satisfied: ruamel.yaml.clib>=0.1.2; platform_python_implementation == \"CPython\" and python_version < \"3.8\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ruamel.yaml==0.16.6->datacube_utilities) (0.2.0)\n",
-      "Requirement already satisfied: cachetools>=2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (3.1.1)\n",
-      "Requirement already satisfied: click>=6.6 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (7.0)\n",
-      "Requirement already satisfied: PyYAML>=3.12 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (5.1)\n",
-      "Requirement already satisfied: click-plugins>=1.0.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (1.1.1)\n",
-      "Requirement already satisfied: traittypes<3,>=0.2.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.12.3->datacube_utilities) (0.2.1)\n",
-      "Requirement already satisfied: branca<0.4,>=0.3.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.12.3->datacube_utilities) (0.3.1)\n",
-      "Requirement already satisfied: ipywidgets<8,>=7.5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.12.3->datacube_utilities) (7.5.1)\n",
-      "Requirement already satisfied: msgpack>=0.6.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (1.0.0)\n",
-      "Requirement already satisfied: tornado>=5; python_version < \"3.8\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (6.0.4)\n",
-      "Requirement already satisfied: toolz>=0.7.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (0.10.0)\n",
-      "Requirement already satisfied: cloudpickle>=0.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (1.3.0)\n",
-      "Requirement already satisfied: sortedcontainers!=2.0.0,!=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (2.1.0)\n",
-      "Requirement already satisfied: psutil>=5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (5.6.3)\n",
-      "Requirement already satisfied: zict>=0.1.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (1.0.0)\n",
-      "Requirement already satisfied: setuptools in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (41.0.1)\n",
-      "Requirement already satisfied: tblib>=1.6.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (1.6.0)\n",
-      "Requirement already satisfied: psycopg2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.8.3)\n",
-      "Requirement already satisfied: sqlalchemy in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.3.5)\n",
-      "Requirement already satisfied: lark-parser>=0.6.7 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (0.8.2)\n",
-      "Requirement already satisfied: affine in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.2.2)\n",
-      "Requirement already satisfied: gdal>=1.9 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.4.1)\n",
-      "Requirement already satisfied: netcdf4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.5.1.2)\n",
-      "Requirement already satisfied: rasterio>=1.0.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.0.22)\n",
-      "Requirement already satisfied: python-dateutil in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.8.0)\n",
-      "Requirement already satisfied: singledispatch in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (3.4.0.3)\n",
-      "Requirement already satisfied: pypeg2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.15.2)\n",
-      "Requirement already satisfied: jsonschema in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (3.0.1)\n",
-      "Requirement already satisfied: pandas>=0.23.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.7.0->datacube_utilities) (1.0.3)\n",
-      "Requirement already satisfied: fiona in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.7.0->datacube_utilities) (1.8.6)\n",
-      "Requirement already satisfied: pyproj>=2.2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.7.0->datacube_utilities) (2.2.1)\n",
-      "Requirement already satisfied: cligj>=0.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.14.0->datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: simplejson in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.14.0->datacube_utilities) (3.16.1)\n",
-      "Requirement already satisfied: requests in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.10.1->datacube_utilities) (2.22.0)\n",
-      "Requirement already satisfied: jinja2>=2.9 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.10.1->datacube_utilities) (2.10.1)\n",
-      "Requirement already satisfied: imageio>=2.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.16.2->datacube_utilities) (2.5.0)\n",
-      "Requirement already satisfied: PyWavelets>=0.4.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.16.2->datacube_utilities) (1.0.3)\n",
-      "Requirement already satisfied: pillow>=4.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.16.2->datacube_utilities) (6.0.0)\n",
-      "Requirement already satisfied: networkx>=2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.16.2->datacube_utilities) (2.3)\n",
-      "Requirement already satisfied: joblib>=0.11 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-learn==0.22.2->datacube_utilities) (0.13.2)\n",
-      "Requirement already satisfied: cycler>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.2.1->datacube_utilities) (0.10.0)\n",
-      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.2.1->datacube_utilities) (2.4.0)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.2.1->datacube_utilities) (1.1.0)\n",
-      "Requirement already satisfied: s3transfer<0.4.0,>=0.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.12.28->datacube_utilities) (0.3.3)\n",
-      "Requirement already satisfied: botocore<1.16.0,>=1.15.28 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.12.28->datacube_utilities) (1.15.29)\n",
-      "Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.12.28->datacube_utilities) (0.9.4)\n",
-      "Requirement already satisfied: traitlets>=4.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from traittypes<3,>=0.2.1->ipyleaflet==0.12.3->datacube_utilities) (4.3.2)\n",
-      "Requirement already satisfied: six in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from branca<0.4,>=0.3.1->ipyleaflet==0.12.3->datacube_utilities) (1.12.0)\n",
-      "Requirement already satisfied: ipython>=4.0.0; python_version >= \"3.3\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (7.5.0)\n",
-      "Requirement already satisfied: ipykernel>=4.5.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (5.1.1)\n",
-      "Requirement already satisfied: widgetsnbextension~=3.5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (3.5.1)\n",
-      "Requirement already satisfied: nbformat>=4.2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (4.4.0)\n",
-      "Requirement already satisfied: heapdict in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from zict>=0.1.3->distributed==2.12.0->datacube_utilities) (1.0.0)\n",
-      "Requirement already satisfied: cftime in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from netcdf4->datacube==1.7->datacube_utilities) (1.0.3.4)\n",
-      "Requirement already satisfied: attrs in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterio>=1.0.2->datacube==1.7->datacube_utilities) (19.1.0)\n",
-      "Requirement already satisfied: snuggs>=1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterio>=1.0.2->datacube==1.7->datacube_utilities) (1.4.6)\n",
-      "Requirement already satisfied: pyrsistent>=0.14.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jsonschema->datacube==1.7->datacube_utilities) (0.15.2)\n",
-      "Requirement already satisfied: pytz>=2017.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pandas>=0.23.0->geopandas==0.7.0->datacube_utilities) (2019.1)\n",
-      "Requirement already satisfied: munch in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from fiona->geopandas==0.7.0->datacube_utilities) (2.3.2)\n",
-      "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.10.1->datacube_utilities) (1.24.3)\n",
-      "Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.10.1->datacube_utilities) (3.0.4)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.10.1->datacube_utilities) (2019.11.28)\n",
-      "Requirement already satisfied: idna<2.9,>=2.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.10.1->datacube_utilities) (2.8)\n",
-      "Requirement already satisfied: MarkupSafe>=0.23 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jinja2>=2.9->folium==0.10.1->datacube_utilities) (1.1.1)\n",
-      "Requirement already satisfied: decorator>=4.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from networkx>=2.0->scikit-image==0.16.2->datacube_utilities) (4.4.0)\n",
-      "Requirement already satisfied: docutils<0.16,>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from botocore<1.16.0,>=1.15.28->boto3==1.12.28->datacube_utilities) (0.14)\n",
-      "Requirement already satisfied: ipython_genutils in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from traitlets>=4.2.2->traittypes<3,>=0.2.1->ipyleaflet==0.12.3->datacube_utilities) (0.2.0)\n",
-      "Requirement already satisfied: pexpect; sys_platform != \"win32\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (4.7.0)\n",
-      "Requirement already satisfied: pygments in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (2.4.2)\n",
-      "Requirement already satisfied: backcall in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.1.0)\n",
-      "Requirement already satisfied: prompt-toolkit<2.1.0,>=2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (2.0.9)\n",
-      "Requirement already satisfied: pickleshare in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.7.5)\n",
-      "Requirement already satisfied: jedi>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.14.0)\n",
-      "Requirement already satisfied: jupyter-client in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipykernel>=4.5.1->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (5.2.4)\n",
-      "Requirement already satisfied: notebook>=4.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (5.7.8)\n",
-      "Requirement already satisfied: jupyter_core in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbformat>=4.2.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (4.4.0)\n",
-      "Requirement already satisfied: ptyprocess>=0.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pexpect; sys_platform != \"win32\"->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.6.0)\n",
-      "Requirement already satisfied: wcwidth in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from prompt-toolkit<2.1.0,>=2.0.0->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.1.7)\n",
-      "Requirement already satisfied: parso>=0.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jedi>=0.10->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: pyzmq>=13 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jupyter-client->ipykernel>=4.5.1->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (18.0.2)\n",
-      "Requirement already satisfied: terminado>=0.8.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.8.2)\n",
-      "Requirement already satisfied: Send2Trash in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (1.5.0)\n",
-      "Requirement already satisfied: nbconvert in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (5.5.0)\n",
-      "Requirement already satisfied: prometheus-client in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.7.1)\n",
-      "Requirement already satisfied: defusedxml in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.5.0)\n",
-      "Requirement already satisfied: bleach in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (3.1.0)\n",
-      "Requirement already satisfied: pandocfilters>=1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (1.4.2)\n",
-      "Requirement already satisfied: entrypoints>=0.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.3)\n",
-      "Requirement already satisfied: testpath in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.4.2)\n",
-      "Requirement already satisfied: mistune>=0.8.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.8.4)\n",
-      "Requirement already satisfied: webencodings in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.5.1)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The dtip fork of datacude_utilities includes some updated requirements which we need for the notebook to run on the updated dask cluster\n",
-    "!pip install git+https://github.com/dtip/datacube-utilities.git#egg=datacube_utilities\n",
+    "#!pip install git+https://github.com/dtip/datacube-utilities.git#egg=datacube_utilities\n",
     "#!pip install git+https://github.com/SatelliteApplicationsCatapult/datacube-utilities.git#egg=datacube_utilities"
    ]
   },
@@ -349,8 +229,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 20.3 ms, sys: 3.41 ms, total: 23.7 ms\n",
-      "Wall time: 22.8 ms\n"
+      "CPU times: user 12.4 ms, sys: 67 µs, total: 12.5 ms\n",
+      "Wall time: 12 ms\n"
      ]
     }
    ],
@@ -371,7 +251,7 @@
      "output_type": "stream",
      "text": [
       "CPU times: user 4 µs, sys: 0 ns, total: 4 µs\n",
-      "Wall time: 7.87 µs\n"
+      "Wall time: 10.5 µs\n"
      ]
     }
    ],
@@ -411,8 +291,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 133 ms, sys: 8.2 ms, total: 142 ms\n",
-      "Wall time: 141 ms\n"
+      "CPU times: user 141 ms, sys: 175 µs, total: 141 ms\n",
+      "Wall time: 140 ms\n"
      ]
     }
    ],
@@ -485,7 +365,7 @@
      "output_type": "stream",
      "text": [
       "CPU times: user 8 µs, sys: 1 µs, total: 9 µs\n",
-      "Wall time: 13.6 µs\n"
+      "Wall time: 14.8 µs\n"
      ]
     }
    ],
@@ -512,8 +392,9 @@
    "outputs": [],
    "source": [
     "dask_chunks=dict(\n",
-    "    x = 1000,\n",
-    "    y = 1000\n",
+    "    time = 100,\n",
+    "    x = 400,\n",
+    "    y = 400\n",
     ")"
    ]
   },
@@ -527,8 +408,8 @@
      "output_type": "stream",
      "text": [
       "(datetime.date(2015, 3, 1), datetime.date(2015, 9, 1))\n",
-      "CPU times: user 1.89 ms, sys: 0 ns, total: 1.89 ms\n",
-      "Wall time: 1.8 ms\n"
+      "CPU times: user 1.7 ms, sys: 0 ns, total: 1.7 ms\n",
+      "Wall time: 1.62 ms\n"
      ]
     }
    ],
@@ -595,13 +476,13 @@
        "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
        "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
        "Data variables:\n",
-       "    green     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    red       (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    blue      (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    nir       (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    swir1     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    swir2     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    pixel_qa  (time, y, x) uint16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    green     (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    red       (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    blue      (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    nir       (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir1     (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir2     (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    pixel_qa  (time, y, x) uint16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
        "Attributes:\n",
        "    crs:      EPSG:3460</pre>"
       ],
@@ -613,13 +494,13 @@
        "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
        "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
        "Data variables:\n",
-       "    green     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    red       (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    blue      (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    nir       (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    swir1     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    swir2     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    pixel_qa  (time, y, x) uint16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    green     (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    red       (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    blue      (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    nir       (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    swir1     (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    swir2     (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    pixel_qa  (time, y, x) uint16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
        "Attributes:\n",
        "    crs:      EPSG:3460"
       ]
@@ -656,13 +537,13 @@
        "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
        "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
        "Data variables:\n",
-       "    green     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    red       (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    blue      (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    nir       (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    swir1     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    swir2     (time, y, x) int16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    pixel_qa  (time, y, x) uint16 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    green     (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    red       (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    blue      (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    nir       (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir1     (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir2     (time, y, x) int16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    pixel_qa  (time, y, x) uint16 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
        "Attributes:\n",
        "    crs:      EPSG:3460</pre>"
       ],
@@ -674,13 +555,13 @@
        "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
        "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
        "Data variables:\n",
-       "    green     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    red       (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    blue      (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    nir       (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    swir1     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    swir2     (time, y, x) int16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    pixel_qa  (time, y, x) uint16 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    green     (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    red       (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    blue      (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    nir       (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    swir1     (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    swir2     (time, y, x) int16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    pixel_qa  (time, y, x) uint16 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
        "Attributes:\n",
        "    crs:      EPSG:3460"
       ]
@@ -711,8 +592,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 822 ms, sys: 41.3 ms, total: 863 ms\n",
-      "Wall time: 914 ms\n"
+      "CPU times: user 744 ms, sys: 35.8 ms, total: 780 ms\n",
+      "Wall time: 835 ms\n"
      ]
     }
    ],
@@ -736,8 +617,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 578 ms, sys: 20.1 ms, total: 599 ms\n",
-      "Wall time: 646 ms\n"
+      "CPU times: user 628 ms, sys: 17.1 ms, total: 645 ms\n",
+      "Wall time: 695 ms\n"
      ]
     }
    ],
@@ -854,8 +735,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 63.4 ms, sys: 0 ns, total: 63.4 ms\n",
-      "Wall time: 62.7 ms\n"
+      "CPU times: user 126 ms, sys: 0 ns, total: 126 ms\n",
+      "Wall time: 130 ms\n"
      ]
     }
    ],
@@ -880,13 +761,13 @@
        "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
        "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
        "Data variables:\n",
-       "    green     (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    red       (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    blue      (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    nir       (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    swir1     (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    swir2     (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
-       "    pixel_qa  (time, y, x) float64 dask.array&lt;chunksize=(1, 259, 210), meta=np.ndarray&gt;\n",
+       "    green     (time, y, x) float64 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    red       (time, y, x) float64 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    blue      (time, y, x) float64 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    nir       (time, y, x) float64 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir1     (time, y, x) float64 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    swir2     (time, y, x) float64 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
+       "    pixel_qa  (time, y, x) float64 dask.array&lt;chunksize=(12, 259, 210), meta=np.ndarray&gt;\n",
        "Attributes:\n",
        "    crs:      EPSG:3460</pre>"
       ],
@@ -898,13 +779,13 @@
        "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
        "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
        "Data variables:\n",
-       "    green     (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    red       (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    blue      (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    nir       (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    swir1     (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    swir2     (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
-       "    pixel_qa  (time, y, x) float64 dask.array<chunksize=(1, 259, 210), meta=np.ndarray>\n",
+       "    green     (time, y, x) float64 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    red       (time, y, x) float64 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    blue      (time, y, x) float64 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    nir       (time, y, x) float64 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    swir1     (time, y, x) float64 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    swir2     (time, y, x) float64 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
+       "    pixel_qa  (time, y, x) float64 dask.array<chunksize=(12, 259, 210), meta=np.ndarray>\n",
        "Attributes:\n",
        "    crs:      EPSG:3460"
       ]
@@ -1019,8 +900,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 23.2 ms, sys: 488 µs, total: 23.7 ms\n",
-      "Wall time: 22.9 ms\n"
+      "CPU times: user 9.49 ms, sys: 277 µs, total: 9.77 ms\n",
+      "Wall time: 9.69 ms\n"
      ]
     }
    ],
@@ -1039,8 +920,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 29 ms, sys: 7.54 ms, total: 36.6 ms\n",
-      "Wall time: 35.4 ms\n"
+      "CPU times: user 11.3 ms, sys: 0 ns, total: 11.3 ms\n",
+      "Wall time: 10.9 ms\n"
      ]
     }
    ],
@@ -1059,8 +940,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 87.8 ms, sys: 3.28 ms, total: 91.1 ms\n",
-      "Wall time: 91.5 ms\n"
+      "CPU times: user 62 ms, sys: 0 ns, total: 62 ms\n",
+      "Wall time: 61.4 ms\n"
      ]
     }
    ],
@@ -1118,8 +999,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 13.2 ms, sys: 190 µs, total: 13.4 ms\n",
-      "Wall time: 13.3 ms\n"
+      "CPU times: user 12.9 ms, sys: 164 µs, total: 13.1 ms\n",
+      "Wall time: 12.9 ms\n"
      ]
     }
    ],
@@ -1141,8 +1022,8 @@
      "text": [
       "0.15.0\n",
       "2.12.0\n",
-      "CPU times: user 2.6 ms, sys: 0 ns, total: 2.6 ms\n",
-      "Wall time: 2.51 ms\n"
+      "CPU times: user 2.33 ms, sys: 0 ns, total: 2.33 ms\n",
+      "Wall time: 2.27 ms\n"
      ]
     }
    ],
@@ -1157,15 +1038,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 993 ms, sys: 109 ms, total: 1.1 s\n",
-      "Wall time: 1min 5s\n"
+      "CPU times: user 733 ms, sys: 34.4 ms, total: 768 ms\n",
+      "Wall time: 1min\n"
      ]
     }
    ],
@@ -1194,7 +1075,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7f48fa1abe80>"
+       "<matplotlib.collections.QuadMesh at 0x7efd44ca0160>"
       ]
      },
      "execution_count": 40,

--- a/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
+++ b/dask_conversions/done/Dask_NDVI_Anomaly.ipynb
@@ -22,140 +22,168 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#!pip install git+https://github.com/dtip/datacube-utilities.git#egg=datacube_utilities\n",
-    "#!pip install git+https://github.com/SatelliteApplicationsCatapult/datacube-utilities.git#egg=datacube_utilities"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# We seem to be hitting an old xarray bug using v0.12.1. See https://github.com/pydata/xarray/issues/3171 and https://github.com/pydata/xarray/pull/3173\n",
-    "# We want at least xarray version 0.13.0\n",
-    "#!pip install xarray --upgrade\n",
-    "#!pip install dask --upgrade\n",
-    "#!pip uninstall -y xarray dask\n",
-    "#!pip install xarray==0.13.0\n",
-    "#!pip install blosc==1.8.1 pandas==0.24.2\n",
-    "#!pip install blosc==1.8.3 cloudpickle==1.3.0 lz4==3.0.2 msgpack==1.0.0 numpy==1.18.1 toolz==0.10.0 tornado==6.0.4"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.15.0\n",
-      "2.12.0\n"
+      "Requirement already satisfied: datacube_utilities from git+https://github.com/dtip/datacube-utilities.git#egg=datacube_utilities in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (0.0.1)\n",
+      "Requirement already satisfied: hdmedians==0.13 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.13)\n",
+      "Requirement already satisfied: ruamel.yaml==0.16.6 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.16.6)\n",
+      "Requirement already satisfied: lcmap-pyccd==2017.08.18 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2017.8.18)\n",
+      "Requirement already satisfied: ipyleaflet==0.12.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.12.3)\n",
+      "Requirement already satisfied: distributed==2.12.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2.12.0)\n",
+      "Requirement already satisfied: descartes==1.1.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.1.0)\n",
+      "Requirement already satisfied: datacube==1.7 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.7)\n",
+      "Requirement already satisfied: geopandas==0.7.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.7.0)\n",
+      "Requirement already satisfied: rasterstats==0.14.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.14.0)\n",
+      "Requirement already satisfied: folium==0.10.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.10.1)\n",
+      "Requirement already satisfied: scikit-image==0.16.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.16.2)\n",
+      "Requirement already satisfied: scikit-learn==0.22.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.22.2)\n",
+      "Requirement already satisfied: seaborn==0.10.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.10.0)\n",
+      "Requirement already satisfied: dask==2.12.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (2.12.0)\n",
+      "Requirement already satisfied: xarray==0.15.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (0.15.0)\n",
+      "Requirement already satisfied: matplotlib==3.2.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (3.2.1)\n",
+      "Requirement already satisfied: boto3==1.12.28 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.12.28)\n",
+      "Requirement already satisfied: shapely==1.7.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.7.0)\n",
+      "Requirement already satisfied: scipy==1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube_utilities) (1.4.1)\n",
+      "Requirement already satisfied: numpy in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from hdmedians==0.13->datacube_utilities) (1.18.1)\n",
+      "Requirement already satisfied: Cython>=0.23 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from hdmedians==0.13->datacube_utilities) (0.29.15)\n",
+      "Requirement already satisfied: ruamel.yaml.clib>=0.1.2; platform_python_implementation == \"CPython\" and python_version < \"3.8\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ruamel.yaml==0.16.6->datacube_utilities) (0.2.0)\n",
+      "Requirement already satisfied: cachetools>=2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (3.1.1)\n",
+      "Requirement already satisfied: click>=6.6 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (7.0)\n",
+      "Requirement already satisfied: PyYAML>=3.12 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (5.1)\n",
+      "Requirement already satisfied: click-plugins>=1.0.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from lcmap-pyccd==2017.08.18->datacube_utilities) (1.1.1)\n",
+      "Requirement already satisfied: traittypes<3,>=0.2.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.12.3->datacube_utilities) (0.2.1)\n",
+      "Requirement already satisfied: branca<0.4,>=0.3.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.12.3->datacube_utilities) (0.3.1)\n",
+      "Requirement already satisfied: ipywidgets<8,>=7.5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipyleaflet==0.12.3->datacube_utilities) (7.5.1)\n",
+      "Requirement already satisfied: msgpack>=0.6.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (1.0.0)\n",
+      "Requirement already satisfied: tornado>=5; python_version < \"3.8\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (6.0.4)\n",
+      "Requirement already satisfied: toolz>=0.7.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (0.10.0)\n",
+      "Requirement already satisfied: cloudpickle>=0.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (1.3.0)\n",
+      "Requirement already satisfied: sortedcontainers!=2.0.0,!=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (2.1.0)\n",
+      "Requirement already satisfied: psutil>=5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (5.6.3)\n",
+      "Requirement already satisfied: zict>=0.1.3 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (1.0.0)\n",
+      "Requirement already satisfied: setuptools in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (41.0.1)\n",
+      "Requirement already satisfied: tblib>=1.6.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from distributed==2.12.0->datacube_utilities) (1.6.0)\n",
+      "Requirement already satisfied: psycopg2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.8.3)\n",
+      "Requirement already satisfied: sqlalchemy in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.3.5)\n",
+      "Requirement already satisfied: lark-parser>=0.6.7 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (0.8.2)\n",
+      "Requirement already satisfied: affine in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.2.2)\n",
+      "Requirement already satisfied: gdal>=1.9 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.4.1)\n",
+      "Requirement already satisfied: netcdf4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.5.1.2)\n",
+      "Requirement already satisfied: rasterio>=1.0.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (1.0.22)\n",
+      "Requirement already satisfied: python-dateutil in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.8.0)\n",
+      "Requirement already satisfied: singledispatch in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (3.4.0.3)\n",
+      "Requirement already satisfied: pypeg2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (2.15.2)\n",
+      "Requirement already satisfied: jsonschema in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from datacube==1.7->datacube_utilities) (3.0.1)\n",
+      "Requirement already satisfied: pandas>=0.23.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.7.0->datacube_utilities) (1.0.3)\n",
+      "Requirement already satisfied: fiona in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.7.0->datacube_utilities) (1.8.6)\n",
+      "Requirement already satisfied: pyproj>=2.2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from geopandas==0.7.0->datacube_utilities) (2.2.1)\n",
+      "Requirement already satisfied: cligj>=0.4 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.14.0->datacube_utilities) (0.5.0)\n",
+      "Requirement already satisfied: simplejson in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterstats==0.14.0->datacube_utilities) (3.16.1)\n",
+      "Requirement already satisfied: requests in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.10.1->datacube_utilities) (2.22.0)\n",
+      "Requirement already satisfied: jinja2>=2.9 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from folium==0.10.1->datacube_utilities) (2.10.1)\n",
+      "Requirement already satisfied: imageio>=2.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.16.2->datacube_utilities) (2.5.0)\n",
+      "Requirement already satisfied: PyWavelets>=0.4.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.16.2->datacube_utilities) (1.0.3)\n",
+      "Requirement already satisfied: pillow>=4.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.16.2->datacube_utilities) (6.0.0)\n",
+      "Requirement already satisfied: networkx>=2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-image==0.16.2->datacube_utilities) (2.3)\n",
+      "Requirement already satisfied: joblib>=0.11 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from scikit-learn==0.22.2->datacube_utilities) (0.13.2)\n",
+      "Requirement already satisfied: cycler>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.2.1->datacube_utilities) (0.10.0)\n",
+      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.2.1->datacube_utilities) (2.4.0)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from matplotlib==3.2.1->datacube_utilities) (1.1.0)\n",
+      "Requirement already satisfied: s3transfer<0.4.0,>=0.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.12.28->datacube_utilities) (0.3.3)\n",
+      "Requirement already satisfied: botocore<1.16.0,>=1.15.28 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.12.28->datacube_utilities) (1.15.29)\n",
+      "Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from boto3==1.12.28->datacube_utilities) (0.9.4)\n",
+      "Requirement already satisfied: traitlets>=4.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from traittypes<3,>=0.2.1->ipyleaflet==0.12.3->datacube_utilities) (4.3.2)\n",
+      "Requirement already satisfied: six in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from branca<0.4,>=0.3.1->ipyleaflet==0.12.3->datacube_utilities) (1.12.0)\n",
+      "Requirement already satisfied: ipython>=4.0.0; python_version >= \"3.3\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (7.5.0)\n",
+      "Requirement already satisfied: ipykernel>=4.5.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (5.1.1)\n",
+      "Requirement already satisfied: widgetsnbextension~=3.5.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (3.5.1)\n",
+      "Requirement already satisfied: nbformat>=4.2.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (4.4.0)\n",
+      "Requirement already satisfied: heapdict in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from zict>=0.1.3->distributed==2.12.0->datacube_utilities) (1.0.0)\n",
+      "Requirement already satisfied: cftime in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from netcdf4->datacube==1.7->datacube_utilities) (1.0.3.4)\n",
+      "Requirement already satisfied: attrs in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterio>=1.0.2->datacube==1.7->datacube_utilities) (19.1.0)\n",
+      "Requirement already satisfied: snuggs>=1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from rasterio>=1.0.2->datacube==1.7->datacube_utilities) (1.4.6)\n",
+      "Requirement already satisfied: pyrsistent>=0.14.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jsonschema->datacube==1.7->datacube_utilities) (0.15.2)\n",
+      "Requirement already satisfied: pytz>=2017.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pandas>=0.23.0->geopandas==0.7.0->datacube_utilities) (2019.1)\n",
+      "Requirement already satisfied: munch in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from fiona->geopandas==0.7.0->datacube_utilities) (2.3.2)\n",
+      "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.10.1->datacube_utilities) (1.24.3)\n",
+      "Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.10.1->datacube_utilities) (3.0.4)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.10.1->datacube_utilities) (2019.11.28)\n",
+      "Requirement already satisfied: idna<2.9,>=2.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from requests->folium==0.10.1->datacube_utilities) (2.8)\n",
+      "Requirement already satisfied: MarkupSafe>=0.23 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jinja2>=2.9->folium==0.10.1->datacube_utilities) (1.1.1)\n",
+      "Requirement already satisfied: decorator>=4.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from networkx>=2.0->scikit-image==0.16.2->datacube_utilities) (4.4.0)\n",
+      "Requirement already satisfied: docutils<0.16,>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from botocore<1.16.0,>=1.15.28->boto3==1.12.28->datacube_utilities) (0.14)\n",
+      "Requirement already satisfied: ipython_genutils in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from traitlets>=4.2.2->traittypes<3,>=0.2.1->ipyleaflet==0.12.3->datacube_utilities) (0.2.0)\n",
+      "Requirement already satisfied: pexpect; sys_platform != \"win32\" in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (4.7.0)\n",
+      "Requirement already satisfied: pygments in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (2.4.2)\n",
+      "Requirement already satisfied: backcall in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.1.0)\n",
+      "Requirement already satisfied: prompt-toolkit<2.1.0,>=2.0.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (2.0.9)\n",
+      "Requirement already satisfied: pickleshare in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.7.5)\n",
+      "Requirement already satisfied: jedi>=0.10 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.14.0)\n",
+      "Requirement already satisfied: jupyter-client in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from ipykernel>=4.5.1->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (5.2.4)\n",
+      "Requirement already satisfied: notebook>=4.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (5.7.8)\n",
+      "Requirement already satisfied: jupyter_core in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbformat>=4.2.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (4.4.0)\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from pexpect; sys_platform != \"win32\"->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.6.0)\n",
+      "Requirement already satisfied: wcwidth in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from prompt-toolkit<2.1.0,>=2.0.0->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.1.7)\n",
+      "Requirement already satisfied: parso>=0.3.0 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jedi>=0.10->ipython>=4.0.0; python_version >= \"3.3\"->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.5.0)\n",
+      "Requirement already satisfied: pyzmq>=13 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from jupyter-client->ipykernel>=4.5.1->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (18.0.2)\n",
+      "Requirement already satisfied: terminado>=0.8.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.8.2)\n",
+      "Requirement already satisfied: Send2Trash in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (1.5.0)\n",
+      "Requirement already satisfied: nbconvert in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (5.5.0)\n",
+      "Requirement already satisfied: prometheus-client in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.7.1)\n",
+      "Requirement already satisfied: defusedxml in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.5.0)\n",
+      "Requirement already satisfied: bleach in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (3.1.0)\n",
+      "Requirement already satisfied: pandocfilters>=1.4.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (1.4.2)\n",
+      "Requirement already satisfied: entrypoints>=0.2.2 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.3)\n",
+      "Requirement already satisfied: testpath in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.4.2)\n",
+      "Requirement already satisfied: mistune>=0.8.1 in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.8.4)\n",
+      "Requirement already satisfied: webencodings in /opt/conda/envs/cubeenv/lib/python3.6/site-packages (from bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8,>=7.5.0->ipyleaflet==0.12.3->datacube_utilities) (0.5.1)\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "# The dtip fork of datacude_utilities includes some updated requirements which we need for the notebook to run on the updated dask cluster\n",
+    "!pip install git+https://github.com/dtip/datacube-utilities.git#egg=datacube_utilities\n",
+    "#!pip install git+https://github.com/SatelliteApplicationsCatapult/datacube-utilities.git#egg=datacube_utilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
     {
      "data": {
+      "text/html": [
+       "<table style=\"border: 2px solid white;\">\n",
+       "<tr>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Client</h3>\n",
+       "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Scheduler: </b>tcp://dask-scheduler.dask.svc.cluster.local:8786</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://dask-scheduler.dask.svc.cluster.local:8787/status' target='_blank'>http://dask-scheduler.dask.svc.cluster.local:8787/status</a>\n",
+       "</ul>\n",
+       "</td>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Cluster</h3>\n",
+       "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Workers: </b>3</li>\n",
+       "  <li><b>Cores: </b>24</li>\n",
+       "  <li><b>Memory: </b>101.19 GB</li>\n",
+       "</ul>\n",
+       "</td>\n",
+       "</tr>\n",
+       "</table>"
+      ],
       "text/plain": [
-       "{'scheduler': {'host': (('python', '3.6.10.final.0'),\n",
-       "   ('python-bits', 64),\n",
-       "   ('OS', 'Linux'),\n",
-       "   ('OS-release', '4.15.0-54-generic'),\n",
-       "   ('machine', 'x86_64'),\n",
-       "   ('processor', ''),\n",
-       "   ('byteorder', 'little'),\n",
-       "   ('LC_ALL', 'C.UTF-8'),\n",
-       "   ('LANG', 'C.UTF-8')),\n",
-       "  'packages': {'dask': '2.12.0',\n",
-       "   'distributed': '2.12.0',\n",
-       "   'msgpack': '1.0.0',\n",
-       "   'cloudpickle': '1.3.0',\n",
-       "   'tornado': '6.0.4',\n",
-       "   'toolz': '0.10.0',\n",
-       "   'numpy': '1.18.1',\n",
-       "   'lz4': '3.0.2',\n",
-       "   'blosc': '1.8.3'}},\n",
-       " 'workers': {'tcp://10.244.1.166:34261': {'host': (('python',\n",
-       "     '3.6.10.final.0'),\n",
-       "    ('python-bits', 64),\n",
-       "    ('OS', 'Linux'),\n",
-       "    ('OS-release', '4.15.0-54-generic'),\n",
-       "    ('machine', 'x86_64'),\n",
-       "    ('processor', ''),\n",
-       "    ('byteorder', 'little'),\n",
-       "    ('LC_ALL', 'C.UTF-8'),\n",
-       "    ('LANG', 'C.UTF-8')),\n",
-       "   'packages': {'dask': '2.12.0',\n",
-       "    'distributed': '2.12.0',\n",
-       "    'msgpack': '1.0.0',\n",
-       "    'cloudpickle': '1.3.0',\n",
-       "    'tornado': '6.0.4',\n",
-       "    'toolz': '0.10.0',\n",
-       "    'numpy': '1.18.1',\n",
-       "    'lz4': '3.0.2',\n",
-       "    'blosc': '1.8.3'}},\n",
-       "  'tcp://10.244.2.201:43843': {'host': (('python', '3.6.10.final.0'),\n",
-       "    ('python-bits', 64),\n",
-       "    ('OS', 'Linux'),\n",
-       "    ('OS-release', '4.15.0-54-generic'),\n",
-       "    ('machine', 'x86_64'),\n",
-       "    ('processor', ''),\n",
-       "    ('byteorder', 'little'),\n",
-       "    ('LC_ALL', 'C.UTF-8'),\n",
-       "    ('LANG', 'C.UTF-8')),\n",
-       "   'packages': {'dask': '2.12.0',\n",
-       "    'distributed': '2.12.0',\n",
-       "    'msgpack': '1.0.0',\n",
-       "    'cloudpickle': '1.3.0',\n",
-       "    'tornado': '6.0.4',\n",
-       "    'toolz': '0.10.0',\n",
-       "    'numpy': '1.18.1',\n",
-       "    'lz4': '3.0.2',\n",
-       "    'blosc': '1.8.3'}},\n",
-       "  'tcp://10.244.3.182:34655': {'host': (('python', '3.6.10.final.0'),\n",
-       "    ('python-bits', 64),\n",
-       "    ('OS', 'Linux'),\n",
-       "    ('OS-release', '4.15.0-54-generic'),\n",
-       "    ('machine', 'x86_64'),\n",
-       "    ('processor', ''),\n",
-       "    ('byteorder', 'little'),\n",
-       "    ('LC_ALL', 'C.UTF-8'),\n",
-       "    ('LANG', 'C.UTF-8')),\n",
-       "   'packages': {'dask': '2.12.0',\n",
-       "    'distributed': '2.12.0',\n",
-       "    'msgpack': '1.0.0',\n",
-       "    'cloudpickle': '1.3.0',\n",
-       "    'tornado': '6.0.4',\n",
-       "    'toolz': '0.10.0',\n",
-       "    'numpy': '1.18.1',\n",
-       "    'lz4': '3.0.2',\n",
-       "    'blosc': '1.8.3'}}},\n",
-       " 'client': {'host': [('python', '3.6.7.final.0'),\n",
-       "   ('python-bits', 64),\n",
-       "   ('OS', 'Linux'),\n",
-       "   ('OS-release', '4.15.0-54-generic'),\n",
-       "   ('machine', 'x86_64'),\n",
-       "   ('processor', 'x86_64'),\n",
-       "   ('byteorder', 'little'),\n",
-       "   ('LC_ALL', 'en_US.UTF-8'),\n",
-       "   ('LANG', 'en_US.UTF-8')],\n",
-       "  'packages': {'dask': '2.12.0',\n",
-       "   'distributed': '2.12.0',\n",
-       "   'msgpack': '1.0.0',\n",
-       "   'cloudpickle': '1.3.0',\n",
-       "   'tornado': '6.0.4',\n",
-       "   'toolz': '0.10.0',\n",
-       "   'numpy': '1.18.1',\n",
-       "   'lz4': '3.0.2',\n",
-       "   'blosc': '1.8.3'}}}"
+       "<Client: 'tcp://10.244.1.165:8786' processes=3 threads=24, memory=101.19 GB>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -191,17 +219,18 @@
     "\n",
     "CMAP = \"Blues\"\n",
     "\n",
-    "print(xr.__version__)\n",
-    "print(dask.__version__)\n",
+    "assert(xr.__version__ == \"0.15.0\")\n",
+    "assert(dask.__version__ == \"2.12.0\")\n",
     "\n",
     "client = Client('dask-scheduler.dask.svc.cluster.local:8786')\n",
-    "#client = Client(n_workers=2, threads_per_worker=2, memory_limit='1GB')\n",
-    "client.get_versions(check=True)"
+    "\n",
+    "client.get_versions(check=True)\n",
+    "client"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -247,7 +276,7 @@
        "Datacube<index=Index<db=PostgresDb<engine=Engine(postgresql://postgres:***@datacubedb-postgresql.datacubedb.svc.cluster.local:5432/datacube)>>>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -266,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,15 +342,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 16.7 ms, sys: 7.14 ms, total: 23.9 ms\n",
-      "Wall time: 22.7 ms\n"
+      "CPU times: user 20.3 ms, sys: 3.41 ms, total: 23.7 ms\n",
+      "Wall time: 22.8 ms\n"
      ]
     }
    ],
@@ -332,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "scrolled": false
    },
@@ -341,8 +370,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 7 µs, sys: 2 µs, total: 9 µs\n",
-      "Wall time: 16.9 µs\n"
+      "CPU times: user 4 µs, sys: 0 ns, total: 4 µs\n",
+      "Wall time: 7.87 µs\n"
      ]
     }
    ],
@@ -354,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,15 +404,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 167 ms, sys: 11.9 ms, total: 179 ms\n",
-      "Wall time: 179 ms\n"
+      "CPU times: user 133 ms, sys: 8.2 ms, total: 142 ms\n",
+      "Wall time: 141 ms\n"
      ]
     }
    ],
@@ -395,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,15 +477,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 16 µs, sys: 5 µs, total: 21 µs\n",
-      "Wall time: 28.1 µs\n"
+      "CPU times: user 8 µs, sys: 1 µs, total: 9 µs\n",
+      "Wall time: 13.6 µs\n"
      ]
     }
    ],
@@ -468,7 +497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -498,8 +527,8 @@
      "output_type": "stream",
      "text": [
       "(datetime.date(2015, 3, 1), datetime.date(2015, 9, 1))\n",
-      "CPU times: user 4.36 ms, sys: 95 µs, total: 4.45 ms\n",
-      "Wall time: 3.92 ms\n"
+      "CPU times: user 1.89 ms, sys: 0 ns, total: 1.89 ms\n",
+      "Wall time: 1.8 ms\n"
      ]
     }
    ],
@@ -529,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -595,7 +624,7 @@
        "    crs:      EPSG:3460"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -614,7 +643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -656,7 +685,7 @@
        "    crs:      EPSG:3460"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -675,15 +704,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 771 ms, sys: 30.6 ms, total: 801 ms\n",
-      "Wall time: 851 ms\n"
+      "CPU times: user 822 ms, sys: 41.3 ms, total: 863 ms\n",
+      "Wall time: 914 ms\n"
      ]
     }
    ],
@@ -700,15 +729,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 655 ms, sys: 27.7 ms, total: 682 ms\n",
-      "Wall time: 729 ms\n"
+      "CPU times: user 578 ms, sys: 20.1 ms, total: 599 ms\n",
+      "Wall time: 646 ms\n"
      ]
     }
    ],
@@ -732,7 +761,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -749,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +788,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -778,7 +807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -818,15 +847,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 134 ms, sys: 4.44 ms, total: 138 ms\n",
-      "Wall time: 137 ms\n"
+      "CPU times: user 63.4 ms, sys: 0 ns, total: 63.4 ms\n",
+      "Wall time: 62.7 ms\n"
      ]
     }
    ],
@@ -838,7 +867,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -880,7 +909,7 @@
        "    crs:      EPSG:3460"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -905,7 +934,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -917,7 +946,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -926,27 +955,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<pre>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:   (x: 210, y: 259)\n",
+       "Coordinates:\n",
+       "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
+       "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
+       "Data variables:\n",
+       "    green     (y, x) float64 dask.array&lt;chunksize=(259, 210), meta=np.ndarray&gt;\n",
+       "    red       (y, x) float64 dask.array&lt;chunksize=(259, 210), meta=np.ndarray&gt;\n",
+       "    blue      (y, x) float64 dask.array&lt;chunksize=(259, 210), meta=np.ndarray&gt;\n",
+       "    nir       (y, x) float64 dask.array&lt;chunksize=(259, 210), meta=np.ndarray&gt;\n",
+       "    swir1     (y, x) float64 dask.array&lt;chunksize=(259, 210), meta=np.ndarray&gt;\n",
+       "    swir2     (y, x) float64 dask.array&lt;chunksize=(259, 210), meta=np.ndarray&gt;\n",
+       "    pixel_qa  (y, x) float64 dask.array&lt;chunksize=(259, 210), meta=np.ndarray&gt;</pre>"
+      ],
       "text/plain": [
-       "Delayed('create_median_mosaic-848e65a8-c553-4374-8292-1a4cfb768fcd')"
+       "<xarray.Dataset>\n",
+       "Dimensions:   (x: 210, y: 259)\n",
+       "Coordinates:\n",
+       "  * y         (y) float64 3.934e+06 3.934e+06 3.934e+06 ... 3.927e+06 3.927e+06\n",
+       "  * x         (x) float64 2.024e+06 2.024e+06 2.024e+06 ... 2.031e+06 2.031e+06\n",
+       "Data variables:\n",
+       "    green     (y, x) float64 dask.array<chunksize=(259, 210), meta=np.ndarray>\n",
+       "    red       (y, x) float64 dask.array<chunksize=(259, 210), meta=np.ndarray>\n",
+       "    blue      (y, x) float64 dask.array<chunksize=(259, 210), meta=np.ndarray>\n",
+       "    nir       (y, x) float64 dask.array<chunksize=(259, 210), meta=np.ndarray>\n",
+       "    swir1     (y, x) float64 dask.array<chunksize=(259, 210), meta=np.ndarray>\n",
+       "    swir2     (y, x) float64 dask.array<chunksize=(259, 210), meta=np.ndarray>\n",
+       "    pixel_qa  (y, x) float64 dask.array<chunksize=(259, 210), meta=np.ndarray>"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "\n",
-    "baseline_composite = dask.delayed(new_compositor)(baseline_ds, clean_mask = b_good_quality)\n",
-    "analysis_composite = dask.delayed(new_compositor)(analysis_ds, clean_mask = a_good_quality)\n",
-    "\n",
-    "#baseline_composite = new_compositor(baseline_ds, clean_mask = b_good_quality)\n",
-    "#analysis_composite = new_compositor(analysis_ds, clean_mask = a_good_quality)\n",
+    "baseline_composite = new_compositor(baseline_ds, clean_mask = b_good_quality)\n",
+    "analysis_composite = new_compositor(analysis_ds, clean_mask = a_good_quality)\n",
     "\n",
     "baseline_composite"
    ]
@@ -960,15 +1012,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 22.3 ms, sys: 542 µs, total: 22.8 ms\n",
-      "Wall time: 22.2 ms\n"
+      "CPU times: user 23.2 ms, sys: 488 µs, total: 23.7 ms\n",
+      "Wall time: 22.9 ms\n"
      ]
     }
    ],
@@ -980,15 +1032,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 38.1 ms, sys: 499 µs, total: 38.6 ms\n",
-      "Wall time: 37.4 ms\n"
+      "CPU times: user 29 ms, sys: 7.54 ms, total: 36.6 ms\n",
+      "Wall time: 35.4 ms\n"
      ]
     }
    ],
@@ -1000,15 +1052,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 14.8 ms, sys: 3.82 ms, total: 18.6 ms\n",
-      "Wall time: 17.6 ms\n"
+      "CPU times: user 87.8 ms, sys: 3.28 ms, total: 91.1 ms\n",
+      "Wall time: 91.5 ms\n"
      ]
     }
    ],
@@ -1029,7 +1081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1042,7 +1094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1059,15 +1111,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.21 ms, sys: 0 ns, total: 2.21 ms\n",
-      "Wall time: 2.23 ms\n"
+      "CPU times: user 13.2 ms, sys: 190 µs, total: 13.4 ms\n",
+      "Wall time: 13.3 ms\n"
      ]
     }
    ],
@@ -1080,7 +1132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -1089,8 +1141,8 @@
      "text": [
       "0.15.0\n",
       "2.12.0\n",
-      "CPU times: user 518 µs, sys: 128 µs, total: 646 µs\n",
-      "Wall time: 587 µs\n"
+      "CPU times: user 2.6 ms, sys: 0 ns, total: 2.6 ms\n",
+      "Wall time: 2.51 ms\n"
      ]
     }
    ],
@@ -1105,21 +1157,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.15 s, sys: 32 ms, total: 1.18 s\n",
-      "Wall time: 1min 22s\n"
+      "CPU times: user 993 ms, sys: 109 ms, total: 1.1 s\n",
+      "Wall time: 1min 5s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "# It seems like we hit this issues sometimes when connecting to the cluster https://github.com/dask/distributed/issues/2842\n",
     "ndvi_anomaly_output = ndvi_anomaly.compute()"
    ]
   },
@@ -1137,16 +1188,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7f7338ffd588>"
+       "<matplotlib.collections.QuadMesh at 0x7f48fa1abe80>"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1170,7 +1221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
This PR gives a 1.3x speedup on small datasets and at least 4x on larger datasets.

There are 2 main changes:
* Removed all usage of `dask.delayed`
* Increased chunk size

## Removed `dask.delayed` usage

`dask.delayed` was being used in lots of places where it didn't need to be. For example:

```
ndvi_baseline_composite = dask.delayed(NDVI(baseline_composite))
```

The `NDVI` function is an array function. It works directly on xarray objects, which means we don't need to use `dask.delayed` on it. That all happens automatically without us needing to worry about it.

The only performance improvement came from replacing this:
```
baseline_composite = dask.delayed(new_compositor)(baseline_ds, clean_mask = b_good_quality)
```

with
```
baseline_composite = new_compositor(baseline_ds, clean_mask = b_good_quality)
```

Again, the possible functions for `new_compositor` are array functions so we don't need to use `dask.delayed`.  

## Increased chunk size

Increasing chunk size means we're not repeatedly reading small chunks - it reduces the dask scheduler's overhead.

This does almost nothing to the small dataset, but on the larger dataset it prevents unnecessary chunking and gives us a 4x speedup. I imagine this speedup will be even greater for even larger datasets, but this isn't tested.

I've set the chunk size to approx 1GB. I think there's plenty of room to increase this further if we need it.


